### PR TITLE
🧹 Remove unused TodoItem type and related store actions

### DIFF
--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -40,7 +40,6 @@ const initialState: UIState = {
 	reminderTemplates: ["Follow up call", "Check part status", "Confirm booking"],
 	bookingTemplates: ["Morning slot", "Afternoon slot", "Next available"],
 	reasonTemplates: ["Wrong part", "Customer cancelled", "Part damaged"],
-	todos: [],
 	notes: [],
 	partStatuses: defaultPartStatuses,
 	bookingStatuses: defaultBookingStatuses,
@@ -89,37 +88,6 @@ export const createUISlice: StateCreator<
 	removeRepairSystem: (system) => {
 		set((state) => ({
 			repairSystems: state.repairSystems.filter((s) => s !== system),
-		}));
-	},
-
-	addTodo: (text) => {
-		get().pushUndo();
-		set((state) => ({
-			todos: [
-				...state.todos,
-				{
-					id: generateId(),
-					text,
-					completed: false,
-					createdAt: new Date().toISOString(),
-				},
-			],
-		}));
-	},
-
-	toggleTodo: (id) => {
-		get().pushUndo();
-		set((state) => ({
-			todos: state.todos.map((todo) =>
-				todo.id === id ? { ...todo, completed: !todo.completed } : todo,
-			),
-		}));
-	},
-
-	deleteTodo: (id) => {
-		get().pushUndo();
-		set((state) => ({
-			todos: state.todos.filter((todo) => todo.id !== id),
 		}));
 	},
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -4,7 +4,6 @@ import type {
 	PartStatusDef,
 	PendingRow,
 	StickyNote,
-	TodoItem,
 } from "@/types";
 
 export interface OrdersState {
@@ -77,7 +76,6 @@ export interface UIState {
 	reminderTemplates: string[];
 	bookingTemplates: string[];
 	reasonTemplates: string[];
-	todos: TodoItem[];
 	notes: StickyNote[];
 	partStatuses: PartStatusDef[];
 	bookingStatuses: PartStatusDef[];
@@ -94,9 +92,6 @@ export interface UIActions {
 	removeModel: (model: string) => void;
 	addRepairSystem: (system: string) => void;
 	removeRepairSystem: (system: string) => void;
-	addTodo: (text: string) => void;
-	toggleTodo: (id: string) => void;
-	deleteTodo: (id: string) => void;
 	addNote: (content: string, color: string) => void;
 	updateNote: (id: string, content: string) => void;
 	deleteNote: (id: string) => void;

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -51,7 +51,6 @@ export const useAppStore = create<CombinedStore>()(
 				repairSystems: state.repairSystems,
 				isLocked: state.isLocked,
 				notes: state.notes,
-				todos: state.todos,
 				gridStates: state.gridStates,
 				dismissedManagedNotificationKeys:
 					state.dismissedManagedNotificationKeys,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,13 +33,6 @@ export interface AppNotification {
 	managedKey?: string;
 }
 
-export interface TodoItem {
-	id: string;
-	text: string;
-	completed: boolean;
-	createdAt: string;
-}
-
 export interface StickyNote {
 	id: string;
 	content: string;


### PR DESCRIPTION
🎯 **What:** Removed the unused `TodoItem` interface, the associated `todos` array from `UIState` (and its `initialState`), the corresponding actions (`addTodo`, `toggleTodo`, `deleteTodo`), and removed `todos` from the `partialize` configuration in `useAppStore`.

💡 **Why:** `TodoItem` and its related actions are not used anywhere in the codebase. Removing them from `src/store/types.ts`, `src/types/index.ts`, `src/store/slices/uiSlice.ts`, and `src/store/useStore.ts` cleans up the codebase and removes unnecessary logic from both the global state and local storage persistence.

✅ **Verification:**
1. Ran Biome linter via `npx @biomejs/biome check --write src/` and addressed all reported code quality issues.
2. Ran the unit test suite via `vitest run` with all 181 tests passing successfully.
3. Successfully requested code review to verify code correctness. Addressed feedback by making sure that temporary scripts and unexpected `package.json`/`package-lock.json` modifications made only for testing are fully reset before submission.

✨ **Result:** Cleaned up unused global state definitions, reducing code duplication and memory usage slightly, leading to cleaner code.

---
*PR created automatically by Jules for task [18152534124199634934](https://jules.google.com/task/18152534124199634934) started by @mahmoudfarahat2647*