### PR TITLE
Optimize undo/redo slice with diff-based snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"cmdk": "^1.1.1",
 				"date-fns": "^4.1.0",
 				"framer-motion": "^12.23.26",
+				"jsondiffpatch": "^0.7.3",
 				"lucide-react": "^0.468.0",
 				"motion": "^12.27.0",
 				"next": "^15.5.12",
@@ -773,6 +774,12 @@
 			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
 			"integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
 			"license": "MIT"
+		},
+		"node_modules/@dmsnell/diff-match-patch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
+			"integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@emnapi/core": {
 			"version": "1.8.1",
@@ -5369,6 +5376,21 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/jsondiffpatch": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.3.tgz",
+			"integrity": "sha512-zd4dqFiXSYyant2WgSXAZ9+yYqilNVvragVNkNRn2IFZKgjyULNrKRznqN4Zon0MkLueCg+3QaPVCnDAVP20OQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dmsnell/diff-match-patch": "^1.1.0"
+			},
+			"bin": {
+				"jsondiffpatch": "bin/jsondiffpatch.js"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
 			}
 		},
 		"node_modules/knip": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"cmdk": "^1.1.1",
 		"date-fns": "^4.1.0",
 		"framer-motion": "^12.23.26",
+		"jsondiffpatch": "^0.7.3",
 		"lucide-react": "^0.468.0",
 		"motion": "^12.27.0",
 		"next": "^15.5.12",

--- a/src/store/slices/undoRedoSlice.ts
+++ b/src/store/slices/undoRedoSlice.ts
@@ -1,3 +1,4 @@
+import { clone, diff, patch } from "jsondiffpatch";
 import type { StateCreator } from "zustand";
 import type { CombinedStore, UndoRedoActions, UndoRedoState } from "../types";
 
@@ -11,68 +12,113 @@ export const createUndoRedoSlice: StateCreator<
 > = (set, get) => ({
 	undoStack: [],
 	redoStack: [],
+	lastSavedState: null,
 
 	pushUndo: () => {
 		const state = get();
-		const snapshot = {
-			rowData: structuredClone(state.rowData),
-			ordersRowData: structuredClone(state.ordersRowData),
-			bookingRowData: structuredClone(state.bookingRowData),
-			callRowData: structuredClone(state.callRowData),
-			archiveRowData: structuredClone(state.archiveRowData),
+		const currentSnapshot = {
+			rowData: state.rowData,
+			ordersRowData: state.ordersRowData,
+			bookingRowData: state.bookingRowData,
+			callRowData: state.callRowData,
+			archiveRowData: state.archiveRowData,
 		};
 
-		set((state) => ({
-			undoStack: [...state.undoStack, snapshot].slice(-UNDO_STACK_LIMIT),
-			redoStack: [], // New action clears redo stack
-		}));
+		set((state) => {
+			if (!state.lastSavedState) {
+				return {
+					lastSavedState: clone(currentSnapshot),
+					undoStack: [],
+					redoStack: [],
+				};
+			}
+
+			const diffPatch = diff(currentSnapshot, state.lastSavedState);
+			if (!diffPatch) return {}; // No state changes
+
+			const newUndoStack = [...state.undoStack, diffPatch].slice(
+				-UNDO_STACK_LIMIT,
+			);
+
+			return {
+				undoStack: newUndoStack,
+				redoStack: [], // New action clears redo stack
+				lastSavedState: clone(currentSnapshot),
+			};
+		});
 	},
 
 	undo: () => {
 		const state = get();
-		if (state.undoStack.length === 0) return;
+		if (!state.lastSavedState) return;
 
 		const currentSnapshot = {
-			rowData: structuredClone(state.rowData),
-			ordersRowData: structuredClone(state.ordersRowData),
-			bookingRowData: structuredClone(state.bookingRowData),
-			callRowData: structuredClone(state.callRowData),
-			archiveRowData: structuredClone(state.archiveRowData),
+			rowData: state.rowData,
+			ordersRowData: state.ordersRowData,
+			bookingRowData: state.bookingRowData,
+			callRowData: state.callRowData,
+			archiveRowData: state.archiveRowData,
 		};
 
-		const lastSnapshot = state.undoStack[state.undoStack.length - 1];
+		// The forward patch from B (lastSavedState) to C (current)
+		const redoPatch = diff(state.lastSavedState, currentSnapshot);
+
+		// If undoStack is empty AND there's no difference between lastSavedState and current state,
+		// there's nothing to undo anymore.
+		if (state.undoStack.length === 0 && !redoPatch) return;
+
+		// We restore to lastSavedState
+		const appState = clone(state.lastSavedState);
+
+		// Now we pop the last undo patch and compute the new lastSavedState
+		let newLastSavedState = clone(appState);
+		const newUndoStack = [...state.undoStack];
+
+		if (newUndoStack.length > 0) {
+			const lastPatch = newUndoStack.pop();
+			newLastSavedState = patch(clone(appState), lastPatch);
+		}
 
 		set({
-			...lastSnapshot,
-			undoStack: state.undoStack.slice(0, -1),
-			redoStack: [...state.redoStack, currentSnapshot],
+			...appState,
+			undoStack: newUndoStack,
+			redoStack: redoPatch ? [...state.redoStack, redoPatch] : state.redoStack,
+			lastSavedState: newLastSavedState,
 		});
 	},
 
 	redo: () => {
 		const state = get();
-		if (state.redoStack.length === 0) return;
+		if (state.redoStack.length === 0 || !state.lastSavedState) return;
 
 		const currentSnapshot = {
-			rowData: structuredClone(state.rowData),
-			ordersRowData: structuredClone(state.ordersRowData),
-			bookingRowData: structuredClone(state.bookingRowData),
-			callRowData: structuredClone(state.callRowData),
-			archiveRowData: structuredClone(state.archiveRowData),
+			rowData: state.rowData,
+			ordersRowData: state.ordersRowData,
+			bookingRowData: state.bookingRowData,
+			callRowData: state.callRowData,
+			archiveRowData: state.archiveRowData,
 		};
 
-		const nextSnapshot = state.redoStack[state.redoStack.length - 1];
+		const newRedoStack = [...state.redoStack];
+		// Pop redo patch to apply to current state
+		const forwardPatch = newRedoStack.pop();
+		if (!forwardPatch) return; // shouldn't happen but for type safety
+
+		const nextState = patch(clone(currentSnapshot), forwardPatch);
+
+		// Compute undo patch for the new state (diff from nextState back to currentSnapshot)
+		const undoPatch = diff(nextState, currentSnapshot);
 
 		set({
-			...nextSnapshot,
-			redoStack: state.redoStack.slice(0, -1),
-			undoStack: [...state.undoStack, currentSnapshot],
+			...nextState,
+			redoStack: newRedoStack,
+			undoStack: undoPatch ? [...state.undoStack, undoPatch] : state.undoStack,
+			// The state we are reverting to if we click 'undo' next time is the currentSnapshot
+			lastSavedState: clone(currentSnapshot),
 		});
 	},
 
 	clearUndoRedo: () => {
-		set({ undoStack: [], redoStack: [] });
+		set({ undoStack: [], redoStack: [], lastSavedState: null });
 	},
 });
-
-// TODO: If state size grows significantly, consider diff-based snapshots instead of full clones.

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -120,8 +120,9 @@ export interface UndoRedoSnapshot {
 }
 
 export interface UndoRedoState {
-	undoStack: UndoRedoSnapshot[];
-	redoStack: UndoRedoSnapshot[];
+	undoStack: any[];
+	redoStack: any[];
+	lastSavedState?: UndoRedoSnapshot | null;
 }
 
 export interface UndoRedoActions {

--- a/test_redo_logic.ts
+++ b/test_redo_logic.ts
@@ -1,0 +1,114 @@
+import { diff, patch, unpatch, clone } from 'jsondiffpatch';
+
+const state1 = { val: "A" };
+const state2 = { val: "B" };
+const state3 = { val: "C" };
+
+let undoStack: any[] = [];
+let redoStack: any[] = [];
+let lastSavedState: any = null;
+
+function pushUndo(currentSnapshot) {
+    if (!lastSavedState) {
+        lastSavedState = clone(currentSnapshot);
+        undoStack = [];
+        return;
+    }
+
+    const diffPatch = diff(currentSnapshot, lastSavedState);
+    if (!diffPatch) return;
+
+    undoStack.push(diffPatch);
+    redoStack = [];
+    lastSavedState = clone(currentSnapshot);
+}
+
+function undo(currentSnapshot) {
+    if (!lastSavedState) return null;
+
+    const redoPatch = diff(lastSavedState, currentSnapshot);
+    if (undoStack.length === 0 && !redoPatch) return currentSnapshot;
+
+    const appState = clone(lastSavedState);
+
+    let newLastSavedState = clone(appState);
+    let newUndoStack = [...undoStack];
+
+    if (newUndoStack.length > 0) {
+        const lastPatch = newUndoStack.pop();
+        newLastSavedState = patch(clone(appState), lastPatch);
+    }
+
+    if (redoPatch) {
+        redoStack.push(redoPatch);
+    }
+
+    undoStack = newUndoStack;
+    lastSavedState = newLastSavedState;
+
+    return appState;
+}
+
+function redo(currentSnapshot) {
+    if (redoStack.length === 0 || !lastSavedState) return null;
+
+    const newRedoStack = [...redoStack];
+    const forwardPatch = newRedoStack.pop();
+    if (!forwardPatch) return null;
+
+    const nextState = patch(clone(currentSnapshot), forwardPatch);
+
+    // FIX: The undo patch needs to go from nextState to currentSnapshot
+    // Wait, lastSavedState is currently the state PREVIOUS to currentSnapshot (if we just undid)
+    // Actually, in our undo logic:
+    // Undoing from C to B: appState = B, lastSavedState = A.
+    // Redo from B to C: nextState = C.
+    // The undoPatch we want to push to undoStack is diff(C, B).
+    // Is lastSavedState equal to B? No! lastSavedState is A!
+    // Why? Because we undid to B, so `lastSavedState` was updated to A.
+    // Wait, if lastSavedState is A, and we compute diff(C, A), we are skipping B!
+    // Yes! That's the bug.
+
+    // So the undo patch should be:
+    const undoPatch = diff(nextState, currentSnapshot); // diff from C back to B
+
+    if (undoPatch) {
+        undoStack.push(undoPatch);
+    }
+
+    // And lastSavedState should become currentSnapshot (B) before we go to C?
+    // Wait. If current state becomes C, what should lastSavedState be?
+    // When we are at state C, `lastSavedState` is supposed to be the state we undo to (which is B).
+    // But wait! If we are at C, and user clicks undo, we want to go back to B.
+    // `lastSavedState` is what we restore!
+    // So `lastSavedState` MUST be B! But B is `currentSnapshot` before redo!
+    // So `lastSavedState` becomes `currentSnapshot`!
+
+    redoStack = newRedoStack;
+    lastSavedState = clone(currentSnapshot);
+
+    return nextState;
+}
+
+pushUndo(state1); // Save A
+console.log("lastSavedState:", lastSavedState, "undoStack:", undoStack.length);
+pushUndo(state2); // Save B
+console.log("lastSavedState:", lastSavedState, "undoStack:", undoStack.length);
+
+let appState = undo(state3); // Undoes from C to B
+console.log("Undone C->B:", appState, "lastSavedState:", lastSavedState, "undoStack:", undoStack.length, "redoStack:", redoStack.length);
+
+appState = undo(appState); // Undoes from B to A
+console.log("Undone B->A:", appState, "lastSavedState:", lastSavedState, "undoStack:", undoStack.length, "redoStack:", redoStack.length);
+
+// Now redo A -> B
+appState = redo(appState); // Redoes to B
+console.log("Redone A->B:", appState, "lastSavedState:", lastSavedState, "undoStack:", undoStack.length, "redoStack:", redoStack.length);
+
+// And redo B -> C
+appState = redo(appState); // Redoes to C
+console.log("Redone B->C:", appState, "lastSavedState:", lastSavedState, "undoStack:", undoStack.length, "redoStack:", redoStack.length);
+
+// Undoes from C to B again
+appState = undo(appState);
+console.log("Undone C->B again:", appState, "lastSavedState:", lastSavedState, "undoStack:", undoStack.length, "redoStack:", redoStack.length);


### PR DESCRIPTION
Switched from full state clones using structuredClone to diff-based snapshots using jsondiffpatch in undoRedoSlice.ts. This drastically reduces memory footprint and performance overhead as state size grows, specifically resolving the optimization TODO.

Updated pushUndo, undo, and redo functions to properly generate and apply state patches.

---
*PR created automatically by Jules for task [3238063019258650739](https://jules.google.com/task/3238063019258650739) started by @mahmoudfarahat2647*