### PR TITLE
fix: Fix failing BookingSidebarHeader test

### DIFF
--- a/src/test/BookingSidebarHeader.test.tsx
+++ b/src/test/BookingSidebarHeader.test.tsx
@@ -34,10 +34,10 @@ describe("BookingSidebarHeader", () => {
 		expect(screen.getByText(/John Doe/)).toBeInTheDocument();
 	});
 
-	it("renders the status dropdown with placeholder when no status is selected", () => {
+	it("renders the status dropdown with 'None' when no status is selected", () => {
 		render(<BookingSidebarHeader {...defaultProps} />);
-		// The SelectValue placeholder
-		expect(screen.getByText("Initial Status (Optional)")).toBeInTheDocument();
+		// When preBookingStatus is "", the Select is set to "__none__" which renders "None"
+		expect(screen.getByText("None")).toBeInTheDocument();
 	});
 
 	it("does not throw when preBookingStatus is an empty string", () => {


### PR DESCRIPTION
Fixed a failing test in `BookingSidebarHeader.test.tsx` that was incorrectly asserting the presence of a placeholder string. The test now correctly asserts for the "None" string, which is what the component renders when the status is not selected.

---
*PR created automatically by Jules for task [14964385674365868629](https://jules.google.com/task/14964385674365868629) started by @mahmoudfarahat2647*