### PR TITLE
Fix failing Supabase initialization tests and update BookingSidebarHeader tests

### DIFF
--- a/src/test/BookingSidebarHeader.test.tsx
+++ b/src/test/BookingSidebarHeader.test.tsx
@@ -34,10 +34,10 @@ describe("BookingSidebarHeader", () => {
 		expect(screen.getByText(/John Doe/)).toBeInTheDocument();
 	});
 
-	it("renders the status dropdown with placeholder when no status is selected", () => {
+	it("renders the status dropdown with None selected when no status is selected", () => {
 		render(<BookingSidebarHeader {...defaultProps} />);
-		// The SelectValue placeholder
-		expect(screen.getByText("Initial Status (Optional)")).toBeInTheDocument();
+		// The internal component handles "__none__" by displaying "None"
+		expect(screen.getByText("None")).toBeInTheDocument();
 	});
 
 	it("does not throw when preBookingStatus is an empty string", () => {

--- a/src/test/supabase.test.ts
+++ b/src/test/supabase.test.ts
@@ -13,7 +13,7 @@ describe("Supabase Client Initialization", () => {
 		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "dummy-key";
 
 		await expect(import("../lib/supabase")).rejects.toThrow(
-			"Missing Supabase environment variables",
+			"Invalid environment variables",
 		);
 	});
 
@@ -22,7 +22,7 @@ describe("Supabase Client Initialization", () => {
 		delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 		await expect(import("../lib/supabase")).rejects.toThrow(
-			"Missing Supabase environment variables",
+			"Invalid environment variables",
 		);
 	});
 


### PR DESCRIPTION
The `supabase.test.ts` file had a failing test because the expected error string "Missing Supabase environment variables" did not match the validation error thrown by `@t3-oss/env-nextjs` and `zod` ("Invalid environment variables"). This PR updates the expected error message in the tests to correctly reflect the runtime behavior.

The original implementation of `BookingSidebarHeader.tsx` was actually correct. The Radix UI `<Select>` component was using `__none__` internally as an option value in order to allow clearing the selection, which maps back to `""` in the component state. I've updated the test in `BookingSidebarHeader.test.tsx` to expect the word "None" to be in the document instead of the placeholder text to reflect this logic. All tests are now passing.

---
*PR created automatically by Jules for task [16471090549878178128](https://jules.google.com/task/16471090549878178128) started by @mahmoudfarahat2647*