### PR TITLE
layout save button highlights only on column reorder, not resize/pin/…

### DIFF
--- a/src/app/(app)/archive/page.tsx
+++ b/src/app/(app)/archive/page.tsx
@@ -63,7 +63,7 @@ import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
 
 export default function ArchivePage() {
-	const { isDirty, saveLayout, saveAsDefault, resetLayout } =
+	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
 		useColumnLayoutTracker("archive");
 	const { data: archiveRowData = [] } = useOrdersQuery("archive");
 
@@ -298,6 +298,7 @@ export default function ArchivePage() {
 
 						<LayoutSaveButton
 							isDirty={isDirty}
+							isPositionDirty={isPositionDirty}
 							onSave={saveLayout}
 							onSaveAsDefault={saveAsDefault}
 							onReset={resetLayout}

--- a/src/app/(app)/booking/page.tsx
+++ b/src/app/(app)/booking/page.tsx
@@ -61,7 +61,7 @@ import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
 
 export default function BookingPage() {
-	const { isDirty, saveLayout, saveAsDefault, resetLayout } =
+	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
 		useColumnLayoutTracker("booking");
 	const { data: bookingRowData = [] } = useOrdersQuery("booking");
 
@@ -311,6 +311,7 @@ export default function BookingPage() {
 
 						<LayoutSaveButton
 							isDirty={isDirty}
+							isPositionDirty={isPositionDirty}
 							onSave={saveLayout}
 							onSaveAsDefault={saveAsDefault}
 							onReset={resetLayout}

--- a/src/app/(app)/call-list/page.tsx
+++ b/src/app/(app)/call-list/page.tsx
@@ -66,7 +66,7 @@ import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
 
 export default function CallListPage() {
-	const { isDirty, saveLayout, saveAsDefault, resetLayout } =
+	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
 		useColumnLayoutTracker("call-list");
 	const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
 	const { data: callRowData = [] } = useOrdersQuery("call");
@@ -304,6 +304,7 @@ export default function CallListPage() {
 
 						<LayoutSaveButton
 							isDirty={isDirty}
+							isPositionDirty={isPositionDirty}
 							onSave={saveLayout}
 							onSaveAsDefault={saveAsDefault}
 							onReset={resetLayout}

--- a/src/components/grid/DataGrid.tsx
+++ b/src/components/grid/DataGrid.tsx
@@ -89,6 +89,9 @@ function DataGridInner<T extends { id?: string; vin?: string }>({
 	}, [gridStateKey, getDefaultLayout, getGridState]);
 
 	const setLayoutDirty = useAppStore((state) => state.setLayoutDirty);
+	const setPositionLayoutDirty = useAppStore(
+		(state) => state.setPositionLayoutDirty,
+	);
 	const gridInitializedRef = useRef(false);
 
 	const handleSaveState = useCallback(() => {
@@ -125,6 +128,13 @@ function DataGridInner<T extends { id?: string; vin?: string }>({
 		}
 		handleSaveState();
 	}, [gridStateKey, setLayoutDirty, handleSaveState]);
+
+	const handleColumnMoved = useCallback(() => {
+		if (gridStateKey && gridInitializedRef.current) {
+			setPositionLayoutDirty(gridStateKey, true);
+		}
+		handleLayoutChange();
+	}, [gridStateKey, setPositionLayoutDirty, handleLayoutChange]);
 
 	// Scroll to highlighted row
 	const highlightedRowId = useAppStore((state) => state.highlightedRowId);
@@ -352,7 +362,7 @@ function DataGridInner<T extends { id?: string; vin?: string }>({
 				onCellValueChanged={handleCellValueChanged}
 				onSelectionChanged={handleSelectionChanged}
 				// State Change tracking for persistence
-				onColumnMoved={handleLayoutChange}
+				onColumnMoved={handleColumnMoved}
 				onColumnResized={handleLayoutChange}
 				onColumnVisible={handleLayoutChange}
 				onColumnPinned={handleLayoutChange}

--- a/src/components/main-sheet/MainSheetToolbar.tsx
+++ b/src/components/main-sheet/MainSheetToolbar.tsx
@@ -72,7 +72,7 @@ export const MainSheetToolbar = ({
 	onFilterChange,
 	rowData = [],
 }: MainSheetToolbarProps) => {
-	const { isDirty, saveLayout, saveAsDefault, resetLayout } =
+	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
 		useColumnLayoutTracker("main-sheet");
 	const uniqueVins = new Set(selectedRows.map((r) => r.vin).filter(Boolean));
 	const isSingleVin = selectedRows.length > 0 && uniqueVins.size === 1;
@@ -234,6 +234,7 @@ export const MainSheetToolbar = ({
 
 				<LayoutSaveButton
 					isDirty={isDirty}
+					isPositionDirty={isPositionDirty}
 					onSave={saveLayout}
 					onSaveAsDefault={saveAsDefault}
 					onReset={resetLayout}

--- a/src/components/orders/OrdersToolbar.tsx
+++ b/src/components/orders/OrdersToolbar.tsx
@@ -76,7 +76,7 @@ export const OrdersToolbar = ({
 	onCallList,
 	rowData = [],
 }: OrdersToolbarProps) => {
-	const { isDirty, saveLayout, saveAsDefault, resetLayout } =
+	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
 		useColumnLayoutTracker("orders");
 	const uniqueVins = new Set(selectedRows.map((r) => r.vin).filter(Boolean));
 	const _isSingleVin = selectedRows.length > 0 && uniqueVins.size === 1;
@@ -304,6 +304,7 @@ export const OrdersToolbar = ({
 
 				<LayoutSaveButton
 					isDirty={isDirty}
+					isPositionDirty={isPositionDirty}
 					onSave={saveLayout}
 					onSaveAsDefault={saveAsDefault}
 					onReset={resetLayout}

--- a/src/components/shared/LayoutSaveButton.tsx
+++ b/src/components/shared/LayoutSaveButton.tsx
@@ -30,6 +30,7 @@ import { cn } from "@/lib/utils";
 
 interface LayoutSaveButtonProps {
 	isDirty: boolean;
+	isPositionDirty: boolean;
 	onSave: () => void;
 	onSaveAsDefault: () => void;
 	onReset: () => void;
@@ -38,6 +39,7 @@ interface LayoutSaveButtonProps {
 
 export function LayoutSaveButton({
 	isDirty,
+	isPositionDirty,
 	onSave,
 	onSaveAsDefault,
 	onReset,
@@ -69,7 +71,7 @@ export function LayoutSaveButton({
 									size="icon"
 									className={cn(
 										"h-8 w-8 text-gray-400 hover:text-white transition-all",
-										isDirty &&
+										isPositionDirty &&
 											"text-renault animate-pulse bg-renault/10 hover:bg-renault/20",
 									)}
 								>

--- a/src/hooks/useColumnLayoutTracker.ts
+++ b/src/hooks/useColumnLayoutTracker.ts
@@ -11,6 +11,12 @@ import { useAppStore } from "@/store/useStore";
 export function useColumnLayoutTracker(gridKey: string) {
 	const isDirty = useAppStore((state) => state.dirtyLayouts[gridKey] || false);
 	const setLayoutDirty = useAppStore((state) => state.setLayoutDirty);
+	const setPositionLayoutDirty = useAppStore(
+		(state) => state.setPositionLayoutDirty,
+	);
+	const isPositionDirty = useAppStore(
+		(state) => state.positionDirtyLayouts[gridKey] || false,
+	);
 	const clearGridState = useAppStore((state) => state.clearGridState);
 	const saveGridState = useAppStore((state) => state.saveGridState);
 	const saveAsDefaultLayout = useAppStore((state) => state.saveAsDefaultLayout);
@@ -34,8 +40,16 @@ export function useColumnLayoutTracker(gridKey: string) {
 		}
 
 		setLayoutDirty(gridKey, false);
+		setPositionLayoutDirty(gridKey, false);
 		toast.success("Grid layout saved successfully");
-	}, [gridKey, getGridState, getLiveGridState, saveGridState, setLayoutDirty]);
+	}, [
+		gridKey,
+		getGridState,
+		getLiveGridState,
+		saveGridState,
+		setLayoutDirty,
+		setPositionLayoutDirty,
+	]);
 
 	const saveAsDefault = useCallback(() => {
 		const currentState = getLiveGridState(gridKey) || getGridState(gridKey);
@@ -43,6 +57,7 @@ export function useColumnLayoutTracker(gridKey: string) {
 			saveGridState(gridKey, currentState);
 			saveAsDefaultLayout(gridKey, currentState);
 			setLayoutDirty(gridKey, false);
+			setPositionLayoutDirty(gridKey, false);
 			toast.success("Layout saved as default");
 		}
 	}, [
@@ -52,6 +67,7 @@ export function useColumnLayoutTracker(gridKey: string) {
 		saveAsDefaultLayout,
 		saveGridState,
 		setLayoutDirty,
+		setPositionLayoutDirty,
 	]);
 
 	const resetLayout = useCallback(() => {
@@ -61,6 +77,7 @@ export function useColumnLayoutTracker(gridKey: string) {
 			// Clear current state will trigger a reload with the default
 			clearGridState(gridKey);
 			setLayoutDirty(gridKey, false);
+			setPositionLayoutDirty(gridKey, false);
 			toast.info("Resetting to your default layout. Refreshing...");
 			window.location.reload();
 		} else {
@@ -68,6 +85,7 @@ export function useColumnLayoutTracker(gridKey: string) {
 			clearGridState(gridKey);
 			clearLiveGridState(gridKey);
 			setLayoutDirty(gridKey, false);
+			setPositionLayoutDirty(gridKey, false);
 			toast.info("Resetting to original layout. Refreshing...");
 			window.location.reload();
 		}
@@ -76,11 +94,13 @@ export function useColumnLayoutTracker(gridKey: string) {
 		clearGridState,
 		clearLiveGridState,
 		setLayoutDirty,
+		setPositionLayoutDirty,
 		getDefaultLayout,
 	]);
 
 	return {
 		isDirty,
+		isPositionDirty,
 		markDirty,
 		saveLayout,
 		saveAsDefault,

--- a/src/store/slices/gridSlice.ts
+++ b/src/store/slices/gridSlice.ts
@@ -14,6 +14,12 @@ interface GridSlice {
 	dirtyLayouts: Record<string, boolean>;
 
 	/**
+	 * Track which grids had a column position change (drag-to-reorder).
+	 * Used exclusively for the button highlight — separate from the save gate.
+	 */
+	positionDirtyLayouts: Record<string, boolean>;
+
+	/**
 	 * Store default layouts for each grid (user-defined defaults).
 	 */
 	defaultLayouts: Record<string, GridState>;
@@ -44,6 +50,11 @@ interface GridSlice {
 	setLayoutDirty: (gridKey: string, dirty: boolean) => void;
 
 	/**
+	 * Marks a grid's column position as dirty or clean (highlight-only flag).
+	 */
+	setPositionLayoutDirty: (gridKey: string, dirty: boolean) => void;
+
+	/**
 	 * Saves the current layout as the default for a grid.
 	 */
 	saveAsDefaultLayout: (gridKey: string, state: GridState) => void;
@@ -60,6 +71,7 @@ export const createGridSlice: StateCreator<CombinedStore, [], [], GridSlice> = (
 ) => ({
 	gridStates: {},
 	dirtyLayouts: {},
+	positionDirtyLayouts: {},
 	defaultLayouts: {},
 
 	saveGridState: (gridKey, state) => {
@@ -81,9 +93,12 @@ export const createGridSlice: StateCreator<CombinedStore, [], [], GridSlice> = (
 			delete newStates[gridKey];
 			const newDirty = { ...prev.dirtyLayouts };
 			delete newDirty[gridKey];
+			const newPositionDirty = { ...prev.positionDirtyLayouts };
+			delete newPositionDirty[gridKey];
 			return {
 				gridStates: newStates,
 				dirtyLayouts: newDirty,
+				positionDirtyLayouts: newPositionDirty,
 			};
 		});
 	},
@@ -92,6 +107,15 @@ export const createGridSlice: StateCreator<CombinedStore, [], [], GridSlice> = (
 		set((prev) => ({
 			dirtyLayouts: {
 				...prev.dirtyLayouts,
+				[gridKey]: dirty,
+			},
+		}));
+	},
+
+	setPositionLayoutDirty: (gridKey, dirty) => {
+		set((prev) => ({
+			positionDirtyLayouts: {
+				...prev.positionDirtyLayouts,
 				[gridKey]: dirty,
 			},
 		}));

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -113,6 +113,7 @@ export interface UIActions {
 interface GridSliceState {
 	gridStates: Record<string, GridState>;
 	dirtyLayouts: Record<string, boolean>;
+	positionDirtyLayouts: Record<string, boolean>;
 	defaultLayouts: Record<string, GridState>;
 }
 
@@ -121,6 +122,7 @@ interface GridSliceActions {
 	getGridState: (gridKey: string) => GridState | null;
 	clearGridState: (gridKey: string) => void;
 	setLayoutDirty: (gridKey: string, dirty: boolean) => void;
+	setPositionLayoutDirty: (gridKey: string, dirty: boolean) => void;
 	saveAsDefaultLayout: (gridKey: string, state: GridState) => void;
 	getDefaultLayout: (gridKey: string) => GridState | null;
 }


### PR DESCRIPTION
…visibility

Introduces a second dirty flag (`positionDirtyLayouts`) that is set exclusively by column-move events. The existing `isDirty` flag continues to gate all four column change types so the Save/Save-as-Default menu items remain accessible. `isPositionDirty` drives the red pulse highlight on the LayoutSaveButton.