### PR TITLE
refactor(api): deduplicate createServiceClient into shared supabase-admin module

### DIFF
--- a/src/app/api/app-settings/route.ts
+++ b/src/app/api/app-settings/route.ts
@@ -1,19 +1,10 @@
-import { createClient } from "@supabase/supabase-js";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { createServiceClient } from "@/lib/supabase-admin";
 import type { AppSettings } from "@/services/appSettingsService";
 
 export const runtime = "nodejs";
-
-function createServiceClient() {
-	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-	const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-	if (!url || !key) throw new Error("Missing Supabase service configuration");
-	return createClient(url, key, {
-		auth: { persistSession: false, autoRefreshToken: false },
-	});
-}
 
 const PROTECTED_REPAIR_SYSTEMS = ["ضمان"];
 

--- a/src/app/api/mobile-order/route.ts
+++ b/src/app/api/mobile-order/route.ts
@@ -1,20 +1,12 @@
-import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { normalizeNullableCompanyName } from "@/lib/company";
+import { createServiceClient } from "@/lib/supabase-admin";
 import { MobileQuickOrderSchema } from "@/schemas/mobileOrder.schema";
 import { isRateLimited } from "./rateLimiter";
 
 export const runtime = "nodejs";
-
-function createServiceClient() {
-	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-	const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-	if (!url || !key) throw new Error("Missing Supabase service config");
-	return createClient(url, key, {
-		auth: { persistSession: false, autoRefreshToken: false },
-	});
-}
 
 function todayString(): string {
 	const d = new Date();
@@ -25,7 +17,7 @@ function todayString(): string {
 }
 
 async function mergeAppSettings(
-	supabase: ReturnType<typeof createServiceClient>,
+	supabase: SupabaseClient,
 	model: string,
 	repairSystem: string,
 ): Promise<void> {

--- a/src/app/api/quick-templates/route.ts
+++ b/src/app/api/quick-templates/route.ts
@@ -1,8 +1,8 @@
-import { createClient } from "@supabase/supabase-js";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { auth } from "@/lib/auth";
+import { createServiceClient } from "@/lib/supabase-admin";
 
 export const runtime = "nodejs";
 
@@ -11,15 +11,6 @@ const AddTemplateSchema = z.object({
 	category: CategorySchema,
 	text: z.string().trim().min(1).max(200),
 });
-
-function createServiceClient() {
-	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-	const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-	if (!url || !key) throw new Error("Missing Supabase service configuration");
-	return createClient(url, key, {
-		auth: { persistSession: false, autoRefreshToken: false },
-	});
-}
 
 function mapRow(row: Record<string, unknown>) {
 	return {

--- a/src/app/api/report-settings/route.ts
+++ b/src/app/api/report-settings/route.ts
@@ -1,7 +1,7 @@
-import { createClient } from "@supabase/supabase-js";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { createServiceClient } from "@/lib/supabase-admin";
 import type { ReportSettings } from "@/store/types";
 
 export const runtime = "nodejs";
@@ -11,15 +11,6 @@ const DEFAULT_REPORT_SETTINGS = {
 	frequency: "Weekly",
 	is_enabled: false,
 } as const;
-
-function createServiceClient() {
-	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-	const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-	if (!url || !key) throw new Error("Missing Supabase service configuration");
-	return createClient(url, key, {
-		auth: { persistSession: false, autoRefreshToken: false },
-	});
-}
 
 export async function GET(req: NextRequest) {
 	const session = await auth.api.getSession({ headers: req.headers });

--- a/src/app/api/storage-stats/route.ts
+++ b/src/app/api/storage-stats/route.ts
@@ -1,5 +1,4 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { createClient } from "@supabase/supabase-js";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
@@ -9,6 +8,7 @@ import {
 	DB_LIMIT_BYTES,
 	STORAGE_LIMIT_BYTES,
 } from "@/lib/storage-limits";
+import { createServiceClient } from "@/lib/supabase-admin";
 
 export const runtime = "nodejs";
 
@@ -129,26 +129,8 @@ export async function GET(req: NextRequest) {
 	}
 
 	try {
-		const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-		const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-		if (!supabaseUrl || !serviceRoleKey) {
-			console.error("Missing Supabase configuration for storage-stats API");
-			return NextResponse.json(
-				{ error: "Server configuration error" },
-				{ status: 500 },
-			);
-		}
-
-		// Create a service-role client to bypass RLS and access internal schemas
-		const supabase = createClient(supabaseUrl, serviceRoleKey, {
-			auth: {
-				persistSession: false,
-				autoRefreshToken: false,
-			},
-			global: {
-				fetch: createTimeoutFetch(SUPABASE_REQUEST_TIMEOUT_MS),
-			},
+		const supabase = createServiceClient({
+			fetch: createTimeoutFetch(SUPABASE_REQUEST_TIMEOUT_MS),
 		});
 
 		// 1. Get Database Size via RPC

--- a/src/lib/supabase-admin.ts
+++ b/src/lib/supabase-admin.ts
@@ -1,0 +1,19 @@
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Creates a Supabase client authenticated with the service role key.
+ * Bypasses RLS — server-side use only, never expose to the browser.
+ *
+ * @param options.fetch - Optional custom fetch (e.g. with a timeout wrapper).
+ */
+export function createServiceClient(options?: {
+	fetch?: typeof globalThis.fetch;
+}) {
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+	if (!url || !key) throw new Error("Missing Supabase service configuration");
+	return createClient(url, key, {
+		auth: { persistSession: false, autoRefreshToken: false },
+		...(options?.fetch ? { global: { fetch: options.fetch } } : {}),
+	});
+}


### PR DESCRIPTION
## Summary

- Extract duplicated Supabase service-role client factory from 5 API routes into a single shared module at src/lib/supabase-admin.ts
- Remove identical local createServiceClient functions from quick-templates, app-settings, report-settings, and mobile-order routes
- Replace inline createClient(...) block in storage-stats with the shared factory, passing the existing timeout fetch via the new optional fetch parameter
- Net change: **-51 lines** of duplicated boilerplate

## Routes updated

| Route | Change |
|---|---|
| src/lib/supabase-admin.ts | Created - single source of truth |
| src/app/api/mobile-order/route.ts | Removed local factory, import shared |
| src/app/api/quick-templates/route.ts | Removed local factory, import shared |
| src/app/api/app-settings/route.ts | Removed local factory, import shared |
| src/app/api/report-settings/route.ts | Removed local factory, import shared |
| src/app/api/storage-stats/route.ts | Replaced inline block, pass fetch option |

## Test plan

- [x] npm run type-check - clean
- [x] quickTemplatesRoute tests - 10/10 pass
- [x] storageStatsRoute tests - 7/7 pass
- [x] Full test suite - 518 pass (3 pre-existing failures in unrelated reportSettingsService.test.ts)
- [x] No remaining function createServiceClient in src/app/

Generated with [Claude Code](https://claude.com/claude-code)