### PR TITLE
fix: M1/M3/M4 — ORDER_STAGES to constants, CSV cache read, typed Orde…

### DIFF
--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -22,9 +22,14 @@ import {
 	ALLOWED_COMPANIES,
 	type AllowedCompany,
 } from "@/lib/ordersValidationConstants";
-import { getOrdersQueryKey, queryClient } from "@/lib/queryClient";
+import {
+	getOrdersByStageFromCache,
+	getOrdersQueryKey,
+	ORDER_STAGES,
+	queryClient,
+} from "@/lib/queryClient";
 import { cn } from "@/lib/utils";
-import { type OrderStage, orderService } from "@/services/orderService";
+import type { OrderStage } from "@/services/orderService";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
 import {
@@ -193,7 +198,7 @@ export const Header = React.memo(function Header() {
 		};
 	}, [isExportMenuOpen]);
 
-	const handleExport = async (company: AllowedCompany) => {
+	const handleExport = (company: AllowedCompany) => {
 		if (isExporting) return;
 
 		setIsExportMenuOpen(false);
@@ -201,14 +206,13 @@ export const Header = React.memo(function Header() {
 
 		const toastId = toast.loading(`Preparing full ${company} system export...`);
 		try {
-			const rawData = await orderService.getOrders();
-			if (!rawData || rawData.length === 0) {
+			const mappedData: PendingRow[] = ORDER_STAGES.flatMap((stage) =>
+				getOrdersByStageFromCache(stage),
+			);
+			if (mappedData.length === 0) {
 				toast.warning("No data available to export", { id: toastId });
 				return;
 			}
-			const mappedData: PendingRow[] = rawData.map((row) =>
-				orderService.mapSupabaseOrder(row as Record<string, unknown>),
-			);
 
 			const exported = exportAllSystemDataCSV(mappedData, company);
 			if (!exported) {

--- a/src/hooks/queries/useOrdersQuery.ts
+++ b/src/hooks/queries/useOrdersQuery.ts
@@ -1,4 +1,5 @@
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
+import { OrderMappingError } from "@/lib/errors";
 import { type OrderStage, orderService } from "@/services/orderService";
 import type { PendingRow } from "@/types";
 
@@ -11,9 +12,16 @@ export function useOrdersQuery(
 		queryFn: async (): Promise<PendingRow[]> => {
 			const data = await orderService.getOrders(stage);
 			if (!data) return [];
-			return data.map((row) =>
-				orderService.mapSupabaseOrder(row as Record<string, unknown>),
-			);
+			try {
+				return data.map((row) =>
+					orderService.mapSupabaseOrder(row as Record<string, unknown>),
+				);
+			} catch (err) {
+				if (err instanceof OrderMappingError) throw err;
+				throw new OrderMappingError(
+					`Unexpected mapping failure: ${String(err)}`,
+				);
+			}
 		},
 		staleTime: 1000 * 60 * 5, // 5 minutes
 		gcTime: 1000 * 60 * 10, // 10 minutes

--- a/src/hooks/queries/useSaveOrderMutation.ts
+++ b/src/hooks/queries/useSaveOrderMutation.ts
@@ -78,9 +78,15 @@ export function useSaveOrderMutation() {
 			}
 		},
 		onSuccess: (data, variables) => {
-			const mappedRow = orderService.mapSupabaseOrder(
-				data as Record<string, unknown>,
-			);
+			let mappedRow: PendingRow;
+			try {
+				mappedRow = orderService.mapSupabaseOrder(
+					data as Record<string, unknown>,
+				);
+			} catch {
+				// Bad row from DB — onSettled invalidation will refetch correct data
+				return;
+			}
 			// Handle multi-stage cache reconciliation
 			if (variables.sourceStage && variables.sourceStage !== variables.stage) {
 				const sourceCacheKey = getOrdersQueryKey(variables.sourceStage);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import type { OrderStage } from "@/services/orderService";
+
 /**
  * Application-wide timing and limit constants.
  * Centralised here to avoid magic numbers scattered across the codebase.
@@ -29,3 +31,12 @@ export const SUPABASE_REQUEST_TIMEOUT_MS = 30_000;
 
 /** Maximum length for truncated error/warning messages in the UI (chars). */
 export const ERROR_MESSAGE_TRUNCATE_LENGTH = 200;
+
+/** Ordered list of all workflow stages. */
+export const ORDER_STAGES: OrderStage[] = [
+	"orders",
+	"main",
+	"call",
+	"booking",
+	"archive",
+];

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,6 @@
+export class OrderMappingError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "OrderMappingError";
+	}
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -2,13 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import type { OrderStage } from "@/services/orderService";
 import type { PendingRow } from "@/types";
 
-export const ORDER_STAGES: OrderStage[] = [
-	"orders",
-	"main",
-	"call",
-	"booking",
-	"archive",
-];
+export { ORDER_STAGES } from "@/lib/constants";
 
 export const getOrdersQueryKey = (stage: OrderStage) =>
 	["orders", stage] as const;

--- a/src/services/orderMapper.ts
+++ b/src/services/orderMapper.ts
@@ -1,5 +1,6 @@
 import { hasAttachment } from "@/lib/attachment";
 import { normalizeNullableCompanyName } from "@/lib/company";
+import { OrderMappingError } from "@/lib/errors";
 import { PersistedOrderRowSchema } from "@/schemas/order.schema";
 import type { PendingRow } from "@/types";
 
@@ -95,7 +96,7 @@ export function mapSupabaseOrder(row: Record<string, unknown>): PendingRow {
 	// This handles legacy field synchronization via the schema transform
 	const parseResult = PersistedOrderRowSchema.safeParse(resultObj);
 	if (!parseResult.success) {
-		throw new Error(
+		throw new OrderMappingError(
 			`[orderMapper] Row mapping failed for id=${row.id}: ${parseResult.error.issues.map((i: { message: string }) => i.message).join(", ")}`,
 		);
 	}

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -1,6 +1,7 @@
 import type { PostgrestError } from "@supabase/supabase-js";
 import { processBatch } from "@/lib/batchUtils";
 import { normalizeNullableCompanyName } from "@/lib/company";
+import { OrderMappingError } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 import { isUuid } from "@/lib/orderWorkflow";
 import { supabase as supabaseDefault } from "@/lib/supabase";
@@ -123,9 +124,16 @@ export function createOrderService(
 		async fetchMappedOrders(stage: OrderStage): Promise<PendingRow[]> {
 			const data = await service.getOrders(stage);
 			if (!data) return [];
-			return data.map((row) =>
-				service.mapSupabaseOrder(row as Record<string, unknown>),
-			);
+			try {
+				return data.map((row) =>
+					service.mapSupabaseOrder(row as Record<string, unknown>),
+				);
+			} catch (err) {
+				if (err instanceof OrderMappingError) throw err;
+				throw new OrderMappingError(
+					`Unexpected mapping failure in fetchMappedOrders: ${String(err)}`,
+				);
+			}
 		},
 
 		async getDashboardStats() {

--- a/src/store/slices/draftSessionSlice.ts
+++ b/src/store/slices/draftSessionSlice.ts
@@ -1,7 +1,7 @@
 import { toast } from "sonner";
 import type { StateCreator } from "zustand";
 import { hasAttachment } from "@/lib/attachment";
-import { ORDER_STAGES } from "@/lib/queryClient";
+import { ORDER_STAGES } from "@/lib/constants";
 import { BeastModeSchema } from "@/schemas/form.schema";
 import type { OrderStage } from "@/services/orderService";
 import type { PendingRow } from "@/types";


### PR DESCRIPTION
…rMappingError

M1: Move ORDER_STAGES from queryClient singleton to src/lib/constants; re-export from queryClient for backward compat; draftSessionSlice now imports from constants.

M3: Header CSV export reads from React Query cache via ORDER_STAGES.flatMap + getOrdersByStageFromCache instead of a live orderService.getOrders() DB round-trip.

M4: Introduce OrderMappingError (src/lib/errors.ts); throw it in orderMapper instead of plain Error; guard all three unprotected call sites (useOrdersQuery, fetchMappedOrders, useSaveOrderMutation onSuccess) with try/catch.