### PR TITLE
fix: mount TooltipProvider at app root to stop "must be used within T…

### DIFF
--- a/src/app/(app)/archive/page.tsx
+++ b/src/app/(app)/archive/page.tsx
@@ -44,7 +44,6 @@ import { Label } from "@/components/ui/label";
 import {
 	Tooltip,
 	TooltipContent,
-	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useOrdersQuery } from "@/hooks/queries/useOrdersQuery";
@@ -227,262 +226,260 @@ export default function ArchivePage() {
 	}, [partStatuses, handleNoteClick, handleReminderClick, handleAttachClick]);
 
 	return (
-		<TooltipProvider>
-			<div className="space-y-4 h-full flex flex-col">
-				<InfoLabel data={selectedRows[0] || null} />
+		<div className="space-y-4 h-full flex flex-col">
+			<InfoLabel data={selectedRows[0] || null} />
 
-				<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
-					<div className="flex items-center gap-1.5">
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
-									onClick={() => gridApi?.exportDataAsCsv()}
-								>
-									<Download className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Extract</TooltipContent>
-						</Tooltip>
+			<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
+				<div className="flex items-center gap-1.5">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
+								onClick={() => gridApi?.exportDataAsCsv()}
+							>
+								<Download className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Extract</TooltipContent>
+					</Tooltip>
 
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-gray-400 hover:text-white h-8 w-8"
-									onClick={() => setShowFilters(!showFilters)}
-								>
-									<Filter className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Filter</TooltipContent>
-						</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-gray-400 hover:text-white h-8 w-8"
+								onClick={() => setShowFilters(!showFilters)}
+							>
+								<Filter className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Filter</TooltipContent>
+					</Tooltip>
 
-						<LayoutSaveButton
-							isDirty={isDirty}
-							isPositionDirty={isPositionDirty}
-							onSave={saveLayout}
-							onSaveAsDefault={saveAsDefault}
-							onReset={resetLayout}
-						/>
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild>
-										<Button
-											variant="ghost"
-											size="icon"
-											className="text-gray-400 hover:text-white h-8 w-8"
-											disabled={selectedRows.length === 0}
-										>
-											<CheckCircle className="h-4 w-4" />
-										</Button>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent
-										align="end"
-										className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
-									>
-										{partStatuses?.map((status) => {
-											const isHex =
-												status.color?.startsWith("#") ||
-												status.color?.startsWith("rgb");
-											const dotStyle = isHex
-												? { backgroundColor: status.color }
-												: undefined;
-											const colorClass = isHex ? "" : status.color;
-
-											return (
-												<DropdownMenuItem
-													key={status.id}
-													onClick={() => handleUpdatePartStatus(status.label)}
-													className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
-												>
-													<div
-														className={cn("w-2 h-2 rounded-full", colorClass)}
-														style={dotStyle}
-													/>
-													<span className="text-xs">{status.label}</span>
-												</DropdownMenuItem>
-											);
-										})}
-									</DropdownMenuContent>
-								</DropdownMenu>
-							</TooltipTrigger>
-							<TooltipContent>Update Status</TooltipContent>
-						</Tooltip>
-
-						<div className="w-px h-5 bg-white/10 mx-1" />
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
-									onClick={() => setIsReorderModalOpen(true)}
-									disabled={selectedRows.length === 0}
-								>
-									<RotateCcw className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Reorder</TooltipContent>
-						</Tooltip>
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-green-500/80 hover:text-green-500 h-8 w-8"
-									onClick={() => setIsBookingModalOpen(true)}
-									disabled={selectedRows.length === 0}
-								>
-									<Calendar className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Reschedule Booking</TooltipContent>
-						</Tooltip>
-					</div>
-
-					<div className="flex items-center gap-1.5">
-						<SelectAllByVinButton
-							onSelectAllByVin={onSelectAllByVin}
-							isDisabled={isSelectAllByVinDisabled}
-						/>
-						<VINLineCounter rows={effectiveData} />
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
-									onClick={() => setShowDeleteConfirm(true)}
-									disabled={selectedRows.length === 0}
-								>
-									<Trash2 className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Delete</TooltipContent>
-						</Tooltip>
-					</div>
-				</div>
-
-				{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
-				<div
-					role="presentation"
-					className={`flex-1 min-h-[500px] border border-white/10 rounded-xl mt-4 ${
-						scrollDir === "horizontal"
-							? "overflow-x-auto overflow-y-hidden"
-							: "overflow-hidden"
-					}`}
-					onContextMenu={(e) => {
-						e.preventDefault();
-						setScrollDir((d) => (d === "vertical" ? "horizontal" : "vertical"));
-					}}
-				>
-					<DataGrid
-						rowData={effectiveData}
-						columnDefs={columns}
-						gridStateKey="archive"
-						stage="archive"
-						readOnly={draftSaving}
-						onSelectionChange={setSelectedRows}
-						onCellValueChanged={async (params) => {
-							if (
-								params.colDef.field === "rDate" &&
-								params.newValue !== params.oldValue
-							) {
-								const v = params.newValue as string;
-								if (!v?.trim() || Number.isNaN(Date.parse(v))) return;
-								await handleUpdateOrder(params.data.id, { rDate: v });
-							}
-						}}
-						onGridReady={(api) => setGridApi(api)}
-						showFloatingFilters={showFilters}
-						enablePagination={true}
-						pageSize={20}
+					<LayoutSaveButton
+						isDirty={isDirty}
+						isPositionDirty={isPositionDirty}
+						onSave={saveLayout}
+						onSaveAsDefault={saveAsDefault}
+						onReset={resetLayout}
 					/>
+
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="text-gray-400 hover:text-white h-8 w-8"
+										disabled={selectedRows.length === 0}
+									>
+										<CheckCircle className="h-4 w-4" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent
+									align="end"
+									className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
+								>
+									{partStatuses?.map((status) => {
+										const isHex =
+											status.color?.startsWith("#") ||
+											status.color?.startsWith("rgb");
+										const dotStyle = isHex
+											? { backgroundColor: status.color }
+											: undefined;
+										const colorClass = isHex ? "" : status.color;
+
+										return (
+											<DropdownMenuItem
+												key={status.id}
+												onClick={() => handleUpdatePartStatus(status.label)}
+												className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
+											>
+												<div
+													className={cn("w-2 h-2 rounded-full", colorClass)}
+													style={dotStyle}
+												/>
+												<span className="text-xs">{status.label}</span>
+											</DropdownMenuItem>
+										);
+									})}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						</TooltipTrigger>
+						<TooltipContent>Update Status</TooltipContent>
+					</Tooltip>
+
+					<div className="w-px h-5 bg-white/10 mx-1" />
+
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
+								onClick={() => setIsReorderModalOpen(true)}
+								disabled={selectedRows.length === 0}
+							>
+								<RotateCcw className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Reorder</TooltipContent>
+					</Tooltip>
+
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-green-500/80 hover:text-green-500 h-8 w-8"
+								onClick={() => setIsBookingModalOpen(true)}
+								disabled={selectedRows.length === 0}
+							>
+								<Calendar className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Reschedule Booking</TooltipContent>
+					</Tooltip>
 				</div>
 
-				<RowModals
-					activeModal={activeModal}
-					currentRow={currentRow}
-					onClose={closeModal}
-					onSaveNote={saveNote}
-					onSaveReminder={saveReminder}
-					onSaveAttachment={saveAttachment}
-					onSaveArchive={() => {}}
-					sourceTag="archive"
-				/>
-
-				{/* Reorder Reason Modal */}
-				<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
-					<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
-						<DialogHeader>
-							<DialogTitle className="text-orange-500">
-								Reorder - Reason Required
-							</DialogTitle>
-						</DialogHeader>
-						<div className="space-y-4">
-							<div>
-								<Label>Reason for Reorder</Label>
-								<Input
-									value={reorderReason}
-									onChange={(e) => setReorderReason(e.target.value)}
-									placeholder="e.g., Customer called back, error in archive"
-									className="bg-white/5 border-white/10 text-white"
-								/>
-							</div>
-							<p className="text-sm text-muted-foreground">
-								This will send the selected items back to the Orders view.
-							</p>
-						</div>
-						<DialogFooter>
+				<div className="flex items-center gap-1.5">
+					<SelectAllByVinButton
+						onSelectAllByVin={onSelectAllByVin}
+						isDisabled={isSelectAllByVinDisabled}
+					/>
+					<VINLineCounter rows={effectiveData} />
+					<Tooltip>
+						<TooltipTrigger asChild>
 							<Button
-								variant="outline"
-								onClick={() => setIsReorderModalOpen(false)}
-								className="border-white/20 text-white hover:bg-white/10"
+								size="icon"
+								variant="ghost"
+								className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
+								onClick={() => setShowDeleteConfirm(true)}
+								disabled={selectedRows.length === 0}
 							>
-								Cancel
+								<Trash2 className="h-3.5 w-3.5" />
 							</Button>
-							<Button
-								variant="renault"
-								onClick={handleConfirmReorder}
-								disabled={!reorderReason.trim()}
-							>
-								Confirm Reorder
-							</Button>
-						</DialogFooter>
-					</DialogContent>
-				</Dialog>
+						</TooltipTrigger>
+						<TooltipContent>Delete</TooltipContent>
+					</Tooltip>
+				</div>
+			</div>
 
-				<BookingCalendarModal
-					open={isBookingModalOpen}
-					onOpenChange={setIsBookingModalOpen}
-					onConfirm={handleConfirmBooking}
-					selectedRows={selectedRows}
-				/>
-
-				<ConfirmDialog
-					open={showDeleteConfirm}
-					onOpenChange={setShowDeleteConfirm}
-					onConfirm={async () => {
-						applyCommand({
-							type: "deleteRows",
-							ids: getSelectedIds(selectedRows),
-						});
-						setSelectedRows([]);
-						toast.success("Archived record(s) deleted");
-						setShowDeleteConfirm(false);
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
+			<div
+				role="presentation"
+				className={`flex-1 min-h-[500px] border border-white/10 rounded-xl mt-4 ${
+					scrollDir === "horizontal"
+						? "overflow-x-auto overflow-y-hidden"
+						: "overflow-hidden"
+				}`}
+				onContextMenu={(e) => {
+					e.preventDefault();
+					setScrollDir((d) => (d === "vertical" ? "horizontal" : "vertical"));
+				}}
+			>
+				<DataGrid
+					rowData={effectiveData}
+					columnDefs={columns}
+					gridStateKey="archive"
+					stage="archive"
+					readOnly={draftSaving}
+					onSelectionChange={setSelectedRows}
+					onCellValueChanged={async (params) => {
+						if (
+							params.colDef.field === "rDate" &&
+							params.newValue !== params.oldValue
+						) {
+							const v = params.newValue as string;
+							if (!v?.trim() || Number.isNaN(Date.parse(v))) return;
+							await handleUpdateOrder(params.data.id, { rDate: v });
+						}
 					}}
-					title="Delete Archived Records"
-					description={`Are you sure you want to permanently delete ${selectedRows.length} selected record(s)?`}
-					confirmText="Permanently Delete"
+					onGridReady={(api) => setGridApi(api)}
+					showFloatingFilters={showFilters}
+					enablePagination={true}
+					pageSize={20}
 				/>
 			</div>
-		</TooltipProvider>
+
+			<RowModals
+				activeModal={activeModal}
+				currentRow={currentRow}
+				onClose={closeModal}
+				onSaveNote={saveNote}
+				onSaveReminder={saveReminder}
+				onSaveAttachment={saveAttachment}
+				onSaveArchive={() => {}}
+				sourceTag="archive"
+			/>
+
+			{/* Reorder Reason Modal */}
+			<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
+				<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
+					<DialogHeader>
+						<DialogTitle className="text-orange-500">
+							Reorder - Reason Required
+						</DialogTitle>
+					</DialogHeader>
+					<div className="space-y-4">
+						<div>
+							<Label>Reason for Reorder</Label>
+							<Input
+								value={reorderReason}
+								onChange={(e) => setReorderReason(e.target.value)}
+								placeholder="e.g., Customer called back, error in archive"
+								className="bg-white/5 border-white/10 text-white"
+							/>
+						</div>
+						<p className="text-sm text-muted-foreground">
+							This will send the selected items back to the Orders view.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setIsReorderModalOpen(false)}
+							className="border-white/20 text-white hover:bg-white/10"
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="renault"
+							onClick={handleConfirmReorder}
+							disabled={!reorderReason.trim()}
+						>
+							Confirm Reorder
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<BookingCalendarModal
+				open={isBookingModalOpen}
+				onOpenChange={setIsBookingModalOpen}
+				onConfirm={handleConfirmBooking}
+				selectedRows={selectedRows}
+			/>
+
+			<ConfirmDialog
+				open={showDeleteConfirm}
+				onOpenChange={setShowDeleteConfirm}
+				onConfirm={async () => {
+					applyCommand({
+						type: "deleteRows",
+						ids: getSelectedIds(selectedRows),
+					});
+					setSelectedRows([]);
+					toast.success("Archived record(s) deleted");
+					setShowDeleteConfirm(false);
+				}}
+				title="Delete Archived Records"
+				description={`Are you sure you want to permanently delete ${selectedRows.length} selected record(s)?`}
+				confirmText="Permanently Delete"
+			/>
+		</div>
 	);
 }

--- a/src/app/(app)/booking/page.tsx
+++ b/src/app/(app)/booking/page.tsx
@@ -42,7 +42,6 @@ import { Label } from "@/components/ui/label";
 import {
 	Tooltip,
 	TooltipContent,
-	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useOrdersQuery } from "@/hooks/queries/useOrdersQuery";
@@ -241,322 +240,319 @@ export default function BookingPage() {
 	};
 
 	return (
-		<TooltipProvider>
-			<div className="space-y-4 h-full flex flex-col">
-				<InfoLabel data={selectedRows[0] || null} />
+		<div className="space-y-4 h-full flex flex-col">
+			<InfoLabel data={selectedRows[0] || null} />
 
-				<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
-					<div className="flex items-center gap-1.5">
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
-									onClick={() => gridApi?.exportDataAsCsv()}
-								>
-									<Download className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Extract</TooltipContent>
-						</Tooltip>
+			<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
+				<div className="flex items-center gap-1.5">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
+								onClick={() => gridApi?.exportDataAsCsv()}
+							>
+								<Download className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Extract</TooltipContent>
+					</Tooltip>
 
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-gray-400 hover:text-white h-8 w-8"
-									onClick={() => setShowFilters(!showFilters)}
-								>
-									<Filter className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Filter</TooltipContent>
-						</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-gray-400 hover:text-white h-8 w-8"
+								onClick={() => setShowFilters(!showFilters)}
+							>
+								<Filter className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Filter</TooltipContent>
+					</Tooltip>
 
-						<LayoutSaveButton
-							isDirty={isDirty}
-							isPositionDirty={isPositionDirty}
-							onSave={saveLayout}
-							onSaveAsDefault={saveAsDefault}
-							onReset={resetLayout}
-						/>
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-gray-400 hover:text-white h-8 w-8"
-									onClick={() => {
-										const reservedRows = filterReservedRows(
-											selectedRows,
-											partStatuses,
-										);
-										if (reservedRows.length === 0) return;
-										printReservationLabels(reservedRows);
-									}}
-									disabled={selectedRows.length === 0}
-								>
-									<Tag className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Reserve/Print Label</TooltipContent>
-						</Tooltip>
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild>
-										<Button
-											variant="ghost"
-											size="icon"
-											className="text-gray-400 hover:text-white h-8 w-8"
-											disabled={selectedRows.length === 0}
-										>
-											<CheckCircle className="h-4 w-4" />
-										</Button>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent
-										align="end"
-										className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
-									>
-										{partStatuses?.map((status) => {
-											const isHex =
-												status.color?.startsWith("#") ||
-												status.color?.startsWith("rgb");
-											const dotStyle = isHex
-												? { backgroundColor: status.color }
-												: undefined;
-											const colorClass = isHex ? "" : status.color;
-
-											return (
-												<DropdownMenuItem
-													key={status.id}
-													onClick={() => handleUpdatePartStatus(status.label)}
-													className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
-												>
-													<div
-														className={cn("w-2 h-2 rounded-full", colorClass)}
-														style={dotStyle}
-													/>
-													<span className="text-xs">{status.label}</span>
-												</DropdownMenuItem>
-											);
-										})}
-									</DropdownMenuContent>
-								</DropdownMenu>
-							</TooltipTrigger>
-							<TooltipContent>Update Status</TooltipContent>
-						</Tooltip>
-
-						<div className="w-px h-5 bg-white/10 mx-1" />
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-gray-400 hover:text-white h-8 w-8"
-									onClick={() => {
-										if (selectedRows.length > 0) {
-											handleArchiveClick(
-												selectedRows[0],
-												selectedRows.map((r) => r.id),
-											);
-										}
-									}}
-									disabled={selectedRows.length === 0 || hasMixedVins}
-								>
-									<Archive className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>
-								{hasMixedVins ? "Mixed customers selected" : "Archive"}
-							</TooltipContent>
-						</Tooltip>
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-green-500/80 hover:text-green-500 h-8 w-8"
-									onClick={() => setIsRebookingModalOpen(true)}
-									disabled={
-										selectedRows.length === 0 || draftDirty || hasMixedVins
-									}
-								>
-									<Calendar className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>
-								{hasMixedVins
-									? "Mixed customers selected"
-									: draftDirty
-										? "Save draft first"
-										: "Reschedule Booking"}
-							</TooltipContent>
-						</Tooltip>
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
-									onClick={() => setIsReorderModalOpen(true)}
-									disabled={selectedRows.length === 0 || hasMixedVins}
-								>
-									<RotateCcw className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>
-								{hasMixedVins ? "Mixed customers selected" : "Reorder"}
-							</TooltipContent>
-						</Tooltip>
-					</div>
-
-					<div className="flex items-center gap-1.5">
-						<SelectAllByVinButton
-							onSelectAllByVin={onSelectAllByVin}
-							isDisabled={isSelectAllByVinDisabled}
-						/>
-						<VINLineCounter rows={effectiveBookingData} />
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
-									onClick={() => setShowDeleteConfirm(true)}
-									disabled={selectedRows.length === 0}
-								>
-									<Trash2 className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Delete</TooltipContent>
-						</Tooltip>
-					</div>
-				</div>
-
-				{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
-				<div
-					role="presentation"
-					className={`flex-1 min-h-[500px] border border-white/10 rounded-xl mt-4 ${
-						scrollDir === "horizontal"
-							? "overflow-x-auto overflow-y-hidden"
-							: "overflow-hidden"
-					}`}
-					onContextMenu={(e) => {
-						e.preventDefault();
-						setScrollDir((d) => (d === "vertical" ? "horizontal" : "vertical"));
-					}}
-				>
-					<DataGrid
-						rowData={effectiveBookingData}
-						columnDefs={columns}
-						gridStateKey="booking"
-						stage="booking"
-						readOnly={draftSaving}
-						onSelectionChange={setSelectedRows}
-						onCellValueChanged={async (params) => {
-							if (
-								params.colDef.field === "rDate" &&
-								params.newValue !== params.oldValue
-							) {
-								const v = params.newValue as string;
-								if (!v?.trim() || Number.isNaN(Date.parse(v))) return;
-								await handleUpdateOrder(params.data.id, { rDate: v });
-							}
-						}}
-						onGridReady={(api) => setGridApi(api)}
-						showFloatingFilters={showFilters}
-						enablePagination={true}
-						pageSize={20}
+					<LayoutSaveButton
+						isDirty={isDirty}
+						isPositionDirty={isPositionDirty}
+						onSave={saveLayout}
+						onSaveAsDefault={saveAsDefault}
+						onReset={resetLayout}
 					/>
+
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-gray-400 hover:text-white h-8 w-8"
+								onClick={() => {
+									const reservedRows = filterReservedRows(
+										selectedRows,
+										partStatuses,
+									);
+									if (reservedRows.length === 0) return;
+									printReservationLabels(reservedRows);
+								}}
+								disabled={selectedRows.length === 0}
+							>
+								<Tag className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Reserve/Print Label</TooltipContent>
+					</Tooltip>
+
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="text-gray-400 hover:text-white h-8 w-8"
+										disabled={selectedRows.length === 0}
+									>
+										<CheckCircle className="h-4 w-4" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent
+									align="end"
+									className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
+								>
+									{partStatuses?.map((status) => {
+										const isHex =
+											status.color?.startsWith("#") ||
+											status.color?.startsWith("rgb");
+										const dotStyle = isHex
+											? { backgroundColor: status.color }
+											: undefined;
+										const colorClass = isHex ? "" : status.color;
+
+										return (
+											<DropdownMenuItem
+												key={status.id}
+												onClick={() => handleUpdatePartStatus(status.label)}
+												className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
+											>
+												<div
+													className={cn("w-2 h-2 rounded-full", colorClass)}
+													style={dotStyle}
+												/>
+												<span className="text-xs">{status.label}</span>
+											</DropdownMenuItem>
+										);
+									})}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						</TooltipTrigger>
+						<TooltipContent>Update Status</TooltipContent>
+					</Tooltip>
+
+					<div className="w-px h-5 bg-white/10 mx-1" />
+
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-gray-400 hover:text-white h-8 w-8"
+								onClick={() => {
+									if (selectedRows.length > 0) {
+										handleArchiveClick(
+											selectedRows[0],
+											selectedRows.map((r) => r.id),
+										);
+									}
+								}}
+								disabled={selectedRows.length === 0 || hasMixedVins}
+							>
+								<Archive className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>
+							{hasMixedVins ? "Mixed customers selected" : "Archive"}
+						</TooltipContent>
+					</Tooltip>
+
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-green-500/80 hover:text-green-500 h-8 w-8"
+								onClick={() => setIsRebookingModalOpen(true)}
+								disabled={
+									selectedRows.length === 0 || draftDirty || hasMixedVins
+								}
+							>
+								<Calendar className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>
+							{hasMixedVins
+								? "Mixed customers selected"
+								: draftDirty
+									? "Save draft first"
+									: "Reschedule Booking"}
+						</TooltipContent>
+					</Tooltip>
+
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
+								onClick={() => setIsReorderModalOpen(true)}
+								disabled={selectedRows.length === 0 || hasMixedVins}
+							>
+								<RotateCcw className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>
+							{hasMixedVins ? "Mixed customers selected" : "Reorder"}
+						</TooltipContent>
+					</Tooltip>
 				</div>
 
-				<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
-					<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
-						<DialogHeader>
-							<DialogTitle className="text-orange-500">
-								Reorder - Reason Required
-							</DialogTitle>
-							<DialogDescription className="sr-only">
-								Provide a reason why this order is being sent back for
-								reordering.
-							</DialogDescription>
-						</DialogHeader>
-						<div className="space-y-4">
-							<div>
-								<Label>Reason for Reorder</Label>
-								<Input
-									value={reorderReason}
-									onChange={(e) => setReorderReason(e.target.value)}
-									placeholder="e.g., Wrong part, Customer cancelled"
-									className="bg-white/5 border-white/10 text-white"
-								/>
-							</div>
-							<p className="text-sm text-muted-foreground">
-								This will send the selected items back to the Orders view.
-							</p>
-						</div>
-						<DialogFooter>
+				<div className="flex items-center gap-1.5">
+					<SelectAllByVinButton
+						onSelectAllByVin={onSelectAllByVin}
+						isDisabled={isSelectAllByVinDisabled}
+					/>
+					<VINLineCounter rows={effectiveBookingData} />
+					<Tooltip>
+						<TooltipTrigger asChild>
 							<Button
-								variant="outline"
-								onClick={() => setIsReorderModalOpen(false)}
-								className="border-white/20 text-white hover:bg-white/10"
+								size="icon"
+								variant="ghost"
+								className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
+								onClick={() => setShowDeleteConfirm(true)}
+								disabled={selectedRows.length === 0}
 							>
-								Cancel
+								<Trash2 className="h-3.5 w-3.5" />
 							</Button>
-							<Button
-								variant="renault"
-								onClick={handleConfirmReorder}
-								disabled={!reorderReason.trim()}
-							>
-								Confirm Reorder
-							</Button>
-						</DialogFooter>
-					</DialogContent>
-				</Dialog>
+						</TooltipTrigger>
+						<TooltipContent>Delete</TooltipContent>
+					</Tooltip>
+				</div>
+			</div>
 
-				<BookingCalendarModal
-					open={isRebookingModalOpen}
-					onOpenChange={setIsRebookingModalOpen}
-					selectedRows={selectedRows}
-					onConfirm={handleConfirmRebooking}
-				/>
-
-				<RowModals
-					activeModal={activeModal}
-					currentRow={currentRow}
-					onClose={closeModal}
-					onSaveNote={saveNote}
-					onSaveReminder={saveReminder}
-					onSaveAttachment={saveAttachment}
-					onSaveArchive={saveArchive}
-					sourceTag="booking"
-				/>
-
-				<ConfirmDialog
-					open={showDeleteConfirm}
-					onOpenChange={setShowDeleteConfirm}
-					onConfirm={async () => {
-						const ids = getSelectedIds(selectedRows);
-						applyCommand({
-							type: "deleteRows",
-							ids,
-						});
-						setSelectedRows([]);
-						toast.success("Booking(s) deleted");
-						setShowDeleteConfirm(false);
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
+			<div
+				role="presentation"
+				className={`flex-1 min-h-[500px] border border-white/10 rounded-xl mt-4 ${
+					scrollDir === "horizontal"
+						? "overflow-x-auto overflow-y-hidden"
+						: "overflow-hidden"
+				}`}
+				onContextMenu={(e) => {
+					e.preventDefault();
+					setScrollDir((d) => (d === "vertical" ? "horizontal" : "vertical"));
+				}}
+			>
+				<DataGrid
+					rowData={effectiveBookingData}
+					columnDefs={columns}
+					gridStateKey="booking"
+					stage="booking"
+					readOnly={draftSaving}
+					onSelectionChange={setSelectedRows}
+					onCellValueChanged={async (params) => {
+						if (
+							params.colDef.field === "rDate" &&
+							params.newValue !== params.oldValue
+						) {
+							const v = params.newValue as string;
+							if (!v?.trim() || Number.isNaN(Date.parse(v))) return;
+							await handleUpdateOrder(params.data.id, { rDate: v });
+						}
 					}}
-					title="Delete Bookings"
-					description={`Are you sure you want to delete ${selectedRows.length} selected booking(s)?`}
-					confirmText="Delete"
+					onGridReady={(api) => setGridApi(api)}
+					showFloatingFilters={showFilters}
+					enablePagination={true}
+					pageSize={20}
 				/>
 			</div>
-		</TooltipProvider>
+
+			<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
+				<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
+					<DialogHeader>
+						<DialogTitle className="text-orange-500">
+							Reorder - Reason Required
+						</DialogTitle>
+						<DialogDescription className="sr-only">
+							Provide a reason why this order is being sent back for reordering.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-4">
+						<div>
+							<Label>Reason for Reorder</Label>
+							<Input
+								value={reorderReason}
+								onChange={(e) => setReorderReason(e.target.value)}
+								placeholder="e.g., Wrong part, Customer cancelled"
+								className="bg-white/5 border-white/10 text-white"
+							/>
+						</div>
+						<p className="text-sm text-muted-foreground">
+							This will send the selected items back to the Orders view.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setIsReorderModalOpen(false)}
+							className="border-white/20 text-white hover:bg-white/10"
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="renault"
+							onClick={handleConfirmReorder}
+							disabled={!reorderReason.trim()}
+						>
+							Confirm Reorder
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<BookingCalendarModal
+				open={isRebookingModalOpen}
+				onOpenChange={setIsRebookingModalOpen}
+				selectedRows={selectedRows}
+				onConfirm={handleConfirmRebooking}
+			/>
+
+			<RowModals
+				activeModal={activeModal}
+				currentRow={currentRow}
+				onClose={closeModal}
+				onSaveNote={saveNote}
+				onSaveReminder={saveReminder}
+				onSaveAttachment={saveAttachment}
+				onSaveArchive={saveArchive}
+				sourceTag="booking"
+			/>
+
+			<ConfirmDialog
+				open={showDeleteConfirm}
+				onOpenChange={setShowDeleteConfirm}
+				onConfirm={async () => {
+					const ids = getSelectedIds(selectedRows);
+					applyCommand({
+						type: "deleteRows",
+						ids,
+					});
+					setSelectedRows([]);
+					toast.success("Booking(s) deleted");
+					setShowDeleteConfirm(false);
+				}}
+				title="Delete Bookings"
+				description={`Are you sure you want to delete ${selectedRows.length} selected booking(s)?`}
+				confirmText="Delete"
+			/>
+		</div>
 	);
 }

--- a/src/app/(app)/call-list/page.tsx
+++ b/src/app/(app)/call-list/page.tsx
@@ -42,7 +42,6 @@ import { Label } from "@/components/ui/label";
 import {
 	Tooltip,
 	TooltipContent,
-	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useOrdersQuery } from "@/hooks/queries/useOrdersQuery";
@@ -244,308 +243,306 @@ export default function CallListPage() {
 	};
 
 	return (
-		<TooltipProvider>
-			<div className="space-y-4 h-full flex flex-col">
-				<InfoLabel data={selectedRows[0] || null} />
+		<div className="space-y-4 h-full flex flex-col">
+			<InfoLabel data={selectedRows[0] || null} />
 
-				<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
-					<div className="flex items-center gap-1.5">
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
-									onClick={() => gridApi?.exportDataAsCsv()}
-								>
-									<Download className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Extract</TooltipContent>
-						</Tooltip>
+			<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
+				<div className="flex items-center gap-1.5">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
+								onClick={() => gridApi?.exportDataAsCsv()}
+							>
+								<Download className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Extract</TooltipContent>
+					</Tooltip>
 
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-gray-400 hover:text-white h-8 w-8"
-									onClick={() => setShowFilters(!showFilters)}
-								>
-									<Filter className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Filter</TooltipContent>
-						</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-gray-400 hover:text-white h-8 w-8"
+								onClick={() => setShowFilters(!showFilters)}
+							>
+								<Filter className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Filter</TooltipContent>
+					</Tooltip>
 
-						<LayoutSaveButton
-							isDirty={isDirty}
-							isPositionDirty={isPositionDirty}
-							onSave={saveLayout}
-							onSaveAsDefault={saveAsDefault}
-							onReset={resetLayout}
-						/>
+					<LayoutSaveButton
+						isDirty={isDirty}
+						isPositionDirty={isPositionDirty}
+						onSave={saveLayout}
+						onSaveAsDefault={saveAsDefault}
+						onReset={resetLayout}
+					/>
 
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-gray-400 hover:text-white h-8 w-8"
-									onClick={() => {
-										const reservedRows = filterReservedRows(
-											selectedRows,
-											partStatuses,
-										);
-										if (reservedRows.length === 0) return;
-										printReservationLabels(reservedRows);
-									}}
-									disabled={selectedRows.length === 0}
-								>
-									<Tag className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Reserve/Print Label</TooltipContent>
-						</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-gray-400 hover:text-white h-8 w-8"
+								onClick={() => {
+									const reservedRows = filterReservedRows(
+										selectedRows,
+										partStatuses,
+									);
+									if (reservedRows.length === 0) return;
+									printReservationLabels(reservedRows);
+								}}
+								disabled={selectedRows.length === 0}
+							>
+								<Tag className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Reserve/Print Label</TooltipContent>
+					</Tooltip>
 
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild>
-										<Button
-											variant="ghost"
-											size="icon"
-											className="text-gray-400 hover:text-white h-8 w-8"
-											disabled={selectedRows.length === 0}
-										>
-											<CheckCircle className="h-4 w-4" />
-										</Button>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent
-										align="end"
-										className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="text-gray-400 hover:text-white h-8 w-8"
+										disabled={selectedRows.length === 0}
 									>
-										{partStatuses?.map((status) => {
-											const isHex =
-												status.color?.startsWith("#") ||
-												status.color?.startsWith("rgb");
-											const dotStyle = isHex
-												? { backgroundColor: status.color }
-												: undefined;
-											const colorClass = isHex ? "" : status.color;
-
-											return (
-												<DropdownMenuItem
-													key={status.id}
-													onClick={() => handleUpdatePartStatus(status.label)}
-													className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
-												>
-													<div
-														className={cn("w-2 h-2 rounded-full", colorClass)}
-														style={dotStyle}
-													/>
-													<span className="text-xs">{status.label}</span>
-												</DropdownMenuItem>
-											);
-										})}
-									</DropdownMenuContent>
-								</DropdownMenu>
-							</TooltipTrigger>
-							<TooltipContent>Update Status</TooltipContent>
-						</Tooltip>
-
-						<div className="w-px h-5 bg-white/10 mx-1" />
-
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-green-500/80 hover:text-green-500 h-8 w-8"
-									disabled={selectedRows.length === 0}
-									onClick={() => setIsBookingModalOpen(true)}
+										<CheckCircle className="h-4 w-4" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent
+									align="end"
+									className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
 								>
-									<Calendar className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Send to Booking</TooltipContent>
-						</Tooltip>
+									{partStatuses?.map((status) => {
+										const isHex =
+											status.color?.startsWith("#") ||
+											status.color?.startsWith("rgb");
+										const dotStyle = isHex
+											? { backgroundColor: status.color }
+											: undefined;
+										const colorClass = isHex ? "" : status.color;
 
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
-									disabled={selectedRows.length === 0}
-									onClick={() => setIsReorderModalOpen(true)}
-								>
-									<RotateCcw className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Send to Reorder</TooltipContent>
-						</Tooltip>
+										return (
+											<DropdownMenuItem
+												key={status.id}
+												onClick={() => handleUpdatePartStatus(status.label)}
+												className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
+											>
+												<div
+													className={cn("w-2 h-2 rounded-full", colorClass)}
+													style={dotStyle}
+												/>
+												<span className="text-xs">{status.label}</span>
+											</DropdownMenuItem>
+										);
+									})}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						</TooltipTrigger>
+						<TooltipContent>Update Status</TooltipContent>
+					</Tooltip>
 
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-gray-400 hover:text-white h-8 w-8"
-									disabled={selectedRows.length === 0}
-									onClick={() =>
-										handleArchiveClick(
-											selectedRows[0],
-											selectedRows.map((r) => r.id),
-										)
-									}
-								>
-									<Archive className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Archive</TooltipContent>
-						</Tooltip>
+					<div className="w-px h-5 bg-white/10 mx-1" />
 
-						<CallRepairSystemFilter
-							options={repairSystemOptions}
-							value={selectedRepairSystems}
-							onChange={setSelectedRepairSystems}
-						/>
-					</div>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-green-500/80 hover:text-green-500 h-8 w-8"
+								disabled={selectedRows.length === 0}
+								onClick={() => setIsBookingModalOpen(true)}
+							>
+								<Calendar className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Send to Booking</TooltipContent>
+					</Tooltip>
 
-					<div className="flex items-center gap-1.5">
-						<SelectAllByVinButton
-							onSelectAllByVin={onSelectAllByVin}
-							isDisabled={isSelectAllByVinDisabled}
-						/>
-						<CallCustomerCounter rows={filteredEffectiveData} />
-						<div className="w-px h-5 bg-white/10 mx-1" />
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
-									onClick={handleDelete}
-									disabled={selectedRows.length === 0}
-								>
-									<Trash2 className="h-3.5 w-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Delete</TooltipContent>
-						</Tooltip>
-					</div>
-				</div>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
+								disabled={selectedRows.length === 0}
+								onClick={() => setIsReorderModalOpen(true)}
+							>
+								<RotateCcw className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Send to Reorder</TooltipContent>
+					</Tooltip>
 
-				{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
-				<div
-					role="presentation"
-					className={`flex-1 min-h-[500px] border border-white/10 rounded-xl mt-4 ${
-						scrollDir === "horizontal"
-							? "overflow-x-auto overflow-y-hidden"
-							: "overflow-hidden"
-					}`}
-					onContextMenu={(e) => {
-						e.preventDefault();
-						setScrollDir((d) => (d === "vertical" ? "horizontal" : "vertical"));
-					}}
-				>
-					<DataGrid
-						rowData={filteredEffectiveData}
-						columnDefs={columns}
-						gridStateKey="call-list"
-						stage="call"
-						readOnly={draftSaving}
-						onSelectionChange={setSelectedRows}
-						onCellValueChanged={async (params) => {
-							if (
-								params.colDef.field === "rDate" &&
-								params.newValue !== params.oldValue
-							) {
-								const v = params.newValue as string;
-								if (!v?.trim() || Number.isNaN(Date.parse(v))) return;
-								await handleUpdateOrder(params.data.id, { rDate: v });
-							}
-						}}
-						onGridReady={(api) => setGridApi(api)}
-						showFloatingFilters={showFilters}
-						enablePagination={true}
-						pageSize={20}
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								className="text-gray-400 hover:text-white h-8 w-8"
+								disabled={selectedRows.length === 0}
+								onClick={() =>
+									handleArchiveClick(
+										selectedRows[0],
+										selectedRows.map((r) => r.id),
+									)
+								}
+							>
+								<Archive className="h-3.5 w-3.5" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Archive</TooltipContent>
+					</Tooltip>
+
+					<CallRepairSystemFilter
+						options={repairSystemOptions}
+						value={selectedRepairSystems}
+						onChange={setSelectedRepairSystems}
 					/>
 				</div>
 
-				<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
-					<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
-						<DialogHeader>
-							<DialogTitle className="text-orange-500">
-								Reorder - Reason Required
-							</DialogTitle>
-						</DialogHeader>
-						<div className="space-y-4">
-							<div>
-								<Label>Reason for Reorder</Label>
-								<Input
-									value={reorderReason}
-									onChange={(e) => setReorderReason(e.target.value)}
-									placeholder="e.g., Wrong part, Customer cancelled"
-									className="bg-white/5 border-white/10 text-white"
-								/>
-							</div>
-							<p className="text-sm text-muted-foreground">
-								This will send the selected items back to the Orders view.
-							</p>
-						</div>
-						<DialogFooter>
+				<div className="flex items-center gap-1.5">
+					<SelectAllByVinButton
+						onSelectAllByVin={onSelectAllByVin}
+						isDisabled={isSelectAllByVinDisabled}
+					/>
+					<CallCustomerCounter rows={filteredEffectiveData} />
+					<div className="w-px h-5 bg-white/10 mx-1" />
+					<Tooltip>
+						<TooltipTrigger asChild>
 							<Button
-								variant="outline"
-								onClick={() => setIsReorderModalOpen(false)}
-								className="border-white/20 text-white hover:bg-white/10"
+								size="icon"
+								variant="ghost"
+								className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
+								onClick={handleDelete}
+								disabled={selectedRows.length === 0}
 							>
-								Cancel
+								<Trash2 className="h-3.5 w-3.5" />
 							</Button>
-							<Button
-								variant="renault"
-								onClick={handleConfirmReorder}
-								disabled={!reorderReason.trim()}
-							>
-								Confirm Reorder
-							</Button>
-						</DialogFooter>
-					</DialogContent>
-				</Dialog>
+						</TooltipTrigger>
+						<TooltipContent>Delete</TooltipContent>
+					</Tooltip>
+				</div>
+			</div>
 
-				<BookingCalendarModal
-					open={isBookingModalOpen}
-					onOpenChange={setIsBookingModalOpen}
-					onConfirm={handleConfirmBooking}
-					selectedRows={selectedRows}
-				/>
-
-				<RowModals
-					activeModal={activeModal}
-					currentRow={currentRow}
-					onClose={closeModal}
-					onSaveNote={saveNote}
-					onSaveReminder={saveReminder}
-					onSaveAttachment={saveAttachment}
-					onSaveArchive={saveArchive}
-				/>
-
-				<ConfirmDialog
-					open={showDeleteConfirm}
-					onOpenChange={setShowDeleteConfirm}
-					onConfirm={async () => {
-						applyCommand({
-							type: "deleteRows",
-							ids: getSelectedIds(selectedRows),
-						});
-						setSelectedRows([]);
-						toast.success("Row(s) deleted");
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
+			<div
+				role="presentation"
+				className={`flex-1 min-h-[500px] border border-white/10 rounded-xl mt-4 ${
+					scrollDir === "horizontal"
+						? "overflow-x-auto overflow-y-hidden"
+						: "overflow-hidden"
+				}`}
+				onContextMenu={(e) => {
+					e.preventDefault();
+					setScrollDir((d) => (d === "vertical" ? "horizontal" : "vertical"));
+				}}
+			>
+				<DataGrid
+					rowData={filteredEffectiveData}
+					columnDefs={columns}
+					gridStateKey="call-list"
+					stage="call"
+					readOnly={draftSaving}
+					onSelectionChange={setSelectedRows}
+					onCellValueChanged={async (params) => {
+						if (
+							params.colDef.field === "rDate" &&
+							params.newValue !== params.oldValue
+						) {
+							const v = params.newValue as string;
+							if (!v?.trim() || Number.isNaN(Date.parse(v))) return;
+							await handleUpdateOrder(params.data.id, { rDate: v });
+						}
 					}}
-					title="Delete Records"
-					description={`Are you sure you want to delete ${selectedRows.length} selected record(s)?`}
-					confirmText="Delete"
+					onGridReady={(api) => setGridApi(api)}
+					showFloatingFilters={showFilters}
+					enablePagination={true}
+					pageSize={20}
 				/>
 			</div>
-		</TooltipProvider>
+
+			<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
+				<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
+					<DialogHeader>
+						<DialogTitle className="text-orange-500">
+							Reorder - Reason Required
+						</DialogTitle>
+					</DialogHeader>
+					<div className="space-y-4">
+						<div>
+							<Label>Reason for Reorder</Label>
+							<Input
+								value={reorderReason}
+								onChange={(e) => setReorderReason(e.target.value)}
+								placeholder="e.g., Wrong part, Customer cancelled"
+								className="bg-white/5 border-white/10 text-white"
+							/>
+						</div>
+						<p className="text-sm text-muted-foreground">
+							This will send the selected items back to the Orders view.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setIsReorderModalOpen(false)}
+							className="border-white/20 text-white hover:bg-white/10"
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="renault"
+							onClick={handleConfirmReorder}
+							disabled={!reorderReason.trim()}
+						>
+							Confirm Reorder
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<BookingCalendarModal
+				open={isBookingModalOpen}
+				onOpenChange={setIsBookingModalOpen}
+				onConfirm={handleConfirmBooking}
+				selectedRows={selectedRows}
+			/>
+
+			<RowModals
+				activeModal={activeModal}
+				currentRow={currentRow}
+				onClose={closeModal}
+				onSaveNote={saveNote}
+				onSaveReminder={saveReminder}
+				onSaveAttachment={saveAttachment}
+				onSaveArchive={saveArchive}
+			/>
+
+			<ConfirmDialog
+				open={showDeleteConfirm}
+				onOpenChange={setShowDeleteConfirm}
+				onConfirm={async () => {
+					applyCommand({
+						type: "deleteRows",
+						ids: getSelectedIds(selectedRows),
+					});
+					setSelectedRows([]);
+					toast.success("Row(s) deleted");
+				}}
+				title="Delete Records"
+				description={`Are you sure you want to delete ${selectedRows.length} selected record(s)?`}
+				confirmText="Delete"
+			/>
+		</div>
 	);
 }

--- a/src/app/(app)/main-sheet/page.tsx
+++ b/src/app/(app)/main-sheet/page.tsx
@@ -35,7 +35,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { useOrdersQuery } from "@/hooks/queries/useOrdersQuery";
 import { useDraftSession } from "@/hooks/useDraftSession";
 import { useRowModals } from "@/hooks/useRowModals";
@@ -284,7 +283,7 @@ export default function MainSheetPage() {
 	};
 
 	return (
-		<TooltipProvider>
+		<>
 			<div className="space-y-4 h-full flex flex-col">
 				<InfoLabel data={selectedRows[0] || null} />
 
@@ -509,6 +508,6 @@ export default function MainSheetPage() {
 				description={`Are you sure you want to delete ${selectedRows.length} selected record(s)?`}
 				confirmText="Delete"
 			/>
-		</TooltipProvider>
+		</>
 	);
 }

--- a/src/app/(app)/orders/page.tsx
+++ b/src/app/(app)/orders/page.tsx
@@ -10,7 +10,6 @@ import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { getOrdersColumns } from "@/components/shared/GridConfig";
 import { InfoLabel } from "@/components/shared/InfoLabel";
 import { Card, CardContent } from "@/components/ui/card";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { useRowModals } from "@/hooks/useRowModals";
 import { getVinAutoMoveIds, hasMixedVinSelection } from "@/lib/orderWorkflow";
 
@@ -130,182 +129,180 @@ export default function OrdersPage() {
 	};
 
 	return (
-		<TooltipProvider>
-			<div className="space-y-6 h-full flex flex-col">
-				<InfoLabel data={selectedRows.length === 1 ? selectedRows[0] : null} />
+		<div className="space-y-6 h-full flex flex-col">
+			<InfoLabel data={selectedRows.length === 1 ? selectedRows[0] : null} />
 
-				<Card className="flex-1 flex flex-col border-none bg-transparent shadow-none">
-					<CardContent className="p-0 flex-1 flex flex-col space-y-4">
-						<OrdersToolbar
-							selectedCount={selectedRows.length}
-							selectedRows={selectedRows}
-							onAddEdit={() => handleOpenForm(selectedRows.length > 0)}
-							onDelete={() => setShowDeleteConfirm(true)}
-							onCommit={handleCommit}
-							onBooking={() => setIsBookingModalOpen(true)}
-							onBulkAttach={() => setIsBulkAttachmentModalOpen(true)}
-							onPrint={handlePrint}
-							onReserve={handleReserve}
-							onArchive={() => {
-								if (selectedRows.length > 0) {
-									handleArchiveClick(
-										selectedRows[0],
-										selectedRows.map((r) => r.id),
-									);
+			<Card className="flex-1 flex flex-col border-none bg-transparent shadow-none">
+				<CardContent className="p-0 flex-1 flex flex-col space-y-4">
+					<OrdersToolbar
+						selectedCount={selectedRows.length}
+						selectedRows={selectedRows}
+						onAddEdit={() => handleOpenForm(selectedRows.length > 0)}
+						onDelete={() => setShowDeleteConfirm(true)}
+						onCommit={handleCommit}
+						onBooking={() => setIsBookingModalOpen(true)}
+						onBulkAttach={() => setIsBulkAttachmentModalOpen(true)}
+						onPrint={handlePrint}
+						onReserve={handleReserve}
+						onArchive={() => {
+							if (selectedRows.length > 0) {
+								handleArchiveClick(
+									selectedRows[0],
+									selectedRows.map((r) => r.id),
+								);
+							}
+						}}
+						onShareToLogistics={handleShareToLogistics}
+						onCallList={handleSendToCallList}
+						onExtract={() => gridApi?.exportDataAsCsv()}
+						onSetAllRDate={handleSetAllRDate}
+						onFilterToggle={() => setShowFilters(!showFilters)}
+						partStatuses={partStatuses}
+						onUpdateStatus={handleUpdatePartStatus}
+						rowData={ordersRowData}
+						onSelectAllByVin={onSelectAllByVin}
+						isSelectAllByVinDisabled={isSelectAllByVinDisabled}
+					/>
+
+					{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
+					<div
+						role="presentation"
+						className={`flex-1 min-h-[500px] border border-white/10 rounded-xl ${
+							scrollDir === "horizontal"
+								? "overflow-x-auto overflow-y-hidden"
+								: "overflow-hidden"
+						}`}
+						onContextMenu={(e) => {
+							e.preventDefault();
+							setScrollDir((d) =>
+								d === "vertical" ? "horizontal" : "vertical",
+							);
+						}}
+					>
+						<DataGrid
+							rowData={ordersRowData}
+							columnDefs={columns}
+							gridStateKey="orders"
+							stage="orders"
+							readOnly={draftSaving}
+							onSelectionChange={setSelectedRows}
+							onCellValueChanged={async (params) => {
+								if (
+									params.colDef.field === "status" &&
+									params.newValue !== params.oldValue
+								) {
+									const newStatus = params.newValue;
+									const vin = params.data.vin;
+
+									// 1. Persist the change
+									await handleUpdateOrder(params.data.id, {
+										status: newStatus,
+									});
+
+									// 2. Check for auto-move to Call List
+									const vinIds = getVinAutoMoveIds({
+										stage: "orders",
+										stageRows: ordersRowData,
+										editedRowId: params.data.id,
+										editedVin: vin,
+										nextStatus: newStatus,
+									});
+
+									if (vinIds.length > 0) {
+										applyCommand({
+											type: "moveRows",
+											ids: vinIds,
+											sourceStage: "orders",
+											destinationStage: "call",
+										});
+										toast.success(
+											`All parts for VIN ${vin} arrived! Moved to Call List.`,
+											{ duration: 5000 },
+										);
+									}
+								} else if (
+									params.colDef.field === "rDate" &&
+									params.newValue !== params.oldValue
+								) {
+									const v = params.newValue as string;
+									if (!v?.trim() || Number.isNaN(Date.parse(v))) return;
+									await handleUpdateOrder(params.data.id, { rDate: v });
 								}
 							}}
-							onShareToLogistics={handleShareToLogistics}
-							onCallList={handleSendToCallList}
-							onExtract={() => gridApi?.exportDataAsCsv()}
-							onSetAllRDate={handleSetAllRDate}
-							onFilterToggle={() => setShowFilters(!showFilters)}
-							partStatuses={partStatuses}
-							onUpdateStatus={handleUpdatePartStatus}
-							rowData={ordersRowData}
-							onSelectAllByVin={onSelectAllByVin}
-							isSelectAllByVinDisabled={isSelectAllByVinDisabled}
+							onGridReady={(api) => setGridApi(api)}
+							showFloatingFilters={showFilters}
+							enablePagination={true}
+							pageSize={20}
 						/>
+					</div>
+				</CardContent>
+			</Card>
 
-						{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
-						<div
-							role="presentation"
-							className={`flex-1 min-h-[500px] border border-white/10 rounded-xl ${
-								scrollDir === "horizontal"
-									? "overflow-x-auto overflow-y-hidden"
-									: "overflow-hidden"
-							}`}
-							onContextMenu={(e) => {
-								e.preventDefault();
-								setScrollDir((d) =>
-									d === "vertical" ? "horizontal" : "vertical",
-								);
-							}}
-						>
-							<DataGrid
-								rowData={ordersRowData}
-								columnDefs={columns}
-								gridStateKey="orders"
-								stage="orders"
-								readOnly={draftSaving}
-								onSelectionChange={setSelectedRows}
-								onCellValueChanged={async (params) => {
-									if (
-										params.colDef.field === "status" &&
-										params.newValue !== params.oldValue
-									) {
-										const newStatus = params.newValue;
-										const vin = params.data.vin;
-
-										// 1. Persist the change
-										await handleUpdateOrder(params.data.id, {
-											status: newStatus,
-										});
-
-										// 2. Check for auto-move to Call List
-										const vinIds = getVinAutoMoveIds({
-											stage: "orders",
-											stageRows: ordersRowData,
-											editedRowId: params.data.id,
-											editedVin: vin,
-											nextStatus: newStatus,
-										});
-
-										if (vinIds.length > 0) {
-											applyCommand({
-												type: "moveRows",
-												ids: vinIds,
-												sourceStage: "orders",
-												destinationStage: "call",
-											});
-											toast.success(
-												`All parts for VIN ${vin} arrived! Moved to Call List.`,
-												{ duration: 5000 },
-											);
-										}
-									} else if (
-										params.colDef.field === "rDate" &&
-										params.newValue !== params.oldValue
-									) {
-										const v = params.newValue as string;
-										if (!v?.trim() || Number.isNaN(Date.parse(v))) return;
-										await handleUpdateOrder(params.data.id, { rDate: v });
-									}
-								}}
-								onGridReady={(api) => setGridApi(api)}
-								showFloatingFilters={showFilters}
-								enablePagination={true}
-								pageSize={20}
-							/>
-						</div>
-					</CardContent>
-				</Card>
-
-				{isFormModalOpen && (
-					<OrderFormErrorBoundary>
-						<OrderFormModal
-							open={isFormModalOpen}
-							onOpenChange={(open) => {
-								setIsFormModalOpen(open);
-							}}
-							isEditMode={isEditMode}
-							selectedRows={selectedRows}
-							onSubmit={handleSaveOrder}
-						/>
-					</OrderFormErrorBoundary>
-				)}
-
-				{currentRow && (
-					<RowModals
-						activeModal={activeModal}
-						currentRow={currentRow}
-						onClose={closeModal}
-						onSaveNote={saveNote}
-						onSaveReminder={saveReminder}
-						onSaveAttachment={saveAttachment}
-						onSaveArchive={saveArchive}
-						sourceTag="orders"
-					/>
-				)}
-
-				{isBulkAttachmentModalOpen && (
-					<EditAttachmentModal
-						open={isBulkAttachmentModalOpen}
-						onOpenChange={setIsBulkAttachmentModalOpen}
-						allowUpload={false}
-						onSave={handleSaveBulkAttachment}
-					/>
-				)}
-
-				{isBookingModalOpen && (
-					<BookingCalendarModal
-						open={isBookingModalOpen}
-						onOpenChange={setIsBookingModalOpen}
-						onConfirm={handleConfirmBooking}
+			{isFormModalOpen && (
+				<OrderFormErrorBoundary>
+					<OrderFormModal
+						open={isFormModalOpen}
+						onOpenChange={(open) => {
+							setIsFormModalOpen(open);
+						}}
+						isEditMode={isEditMode}
 						selectedRows={selectedRows}
+						onSubmit={handleSaveOrder}
 					/>
-				)}
+				</OrderFormErrorBoundary>
+			)}
 
-				<ConfirmDialog
-					open={showDeleteConfirm}
-					onOpenChange={setShowDeleteConfirm}
-					onConfirm={handleDeleteSelected}
-					title="Delete Orders"
-					description={`Are you sure you want to delete ${selectedRows.length} selected order(s)? This action cannot be undone.`}
-					confirmText="Delete"
+			{currentRow && (
+				<RowModals
+					activeModal={activeModal}
+					currentRow={currentRow}
+					onClose={closeModal}
+					onSaveNote={saveNote}
+					onSaveReminder={saveReminder}
+					onSaveAttachment={saveAttachment}
+					onSaveArchive={saveArchive}
+					sourceTag="orders"
 				/>
+			)}
 
-				<ConfirmDialog
-					open={showCommitConfirm}
-					onOpenChange={setShowCommitConfirm}
-					onConfirm={handleConfirmCommit}
-					title="Commit to Main Sheet"
-					description="Have you verified the request date for all selected orders before committing?"
-					confirmText="Commit"
-					cancelText="No, Go Back"
-					variant="success"
-					requireTypeToConfirm="yes"
+			{isBulkAttachmentModalOpen && (
+				<EditAttachmentModal
+					open={isBulkAttachmentModalOpen}
+					onOpenChange={setIsBulkAttachmentModalOpen}
+					allowUpload={false}
+					onSave={handleSaveBulkAttachment}
 				/>
-			</div>
-		</TooltipProvider>
+			)}
+
+			{isBookingModalOpen && (
+				<BookingCalendarModal
+					open={isBookingModalOpen}
+					onOpenChange={setIsBookingModalOpen}
+					onConfirm={handleConfirmBooking}
+					selectedRows={selectedRows}
+				/>
+			)}
+
+			<ConfirmDialog
+				open={showDeleteConfirm}
+				onOpenChange={setShowDeleteConfirm}
+				onConfirm={handleDeleteSelected}
+				title="Delete Orders"
+				description={`Are you sure you want to delete ${selectedRows.length} selected order(s)? This action cannot be undone.`}
+				confirmText="Delete"
+			/>
+
+			<ConfirmDialog
+				open={showCommitConfirm}
+				onOpenChange={setShowCommitConfirm}
+				onConfirm={handleConfirmCommit}
+				title="Commit to Main Sheet"
+				description="Have you verified the request date for all selected orders before committing?"
+				confirmText="Commit"
+				cancelText="No, Go Back"
+				variant="success"
+				requireTypeToConfirm="yes"
+			/>
+		</div>
 	);
 }

--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClientProvider } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { queryClient } from "@/lib/queryClient";
 import {
 	createReactQueryAdapter,
@@ -31,7 +32,7 @@ export default function QueryProvider({
 }) {
 	return (
 		<QueryClientProvider client={queryClient}>
-			{children}
+			<TooltipProvider>{children}</TooltipProvider>
 			{Devtools ? <Devtools initialIsOpen={false} /> : null}
 		</QueryClientProvider>
 	);

--- a/src/components/shared/search/SearchToolbar.tsx
+++ b/src/components/shared/search/SearchToolbar.tsx
@@ -21,7 +21,6 @@ import {
 import {
 	Tooltip,
 	TooltipContent,
-	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -64,222 +63,220 @@ export const SearchToolbar = ({
 	const isStageActionDisabled = selectedCount === 0 || !isSameSource;
 
 	return (
-		<TooltipProvider>
-			<div className="flex items-center justify-between bg-[#141416] p-2 px-6 border-b border-white/5">
-				<div className="flex items-center gap-2">
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								size="icon"
-								className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-lg h-8 w-8"
-								onClick={onReserve}
-								disabled={isReserveDisabled}
-							>
-								<Tag className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Reserve</TooltipContent>
-					</Tooltip>
+		<div className="flex items-center justify-between bg-[#141416] p-2 px-6 border-b border-white/5">
+			<div className="flex items-center gap-2">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							size="icon"
+							className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-lg h-8 w-8"
+							onClick={onReserve}
+							disabled={isReserveDisabled}
+						>
+							<Tag className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Reserve</TooltipContent>
+				</Tooltip>
 
-					<div className="w-px h-6 bg-white/10 mx-1" />
+				<div className="w-px h-6 bg-white/10 mx-1" />
 
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								className={cn(
-									"h-8 w-8 transition-colors",
-									!isStageActionDisabled
-										? "text-green-500 hover:text-green-400 hover:bg-green-500/10"
-										: "text-gray-600 cursor-not-allowed opacity-50",
-								)}
-								disabled={isStageActionDisabled}
-								onClick={onBooking}
-							>
-								<Calendar className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{!isSameSource && selectedCount > 0 ? disabledReason : "Booking"}
-						</TooltipContent>
-					</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className={cn(
+								"h-8 w-8 transition-colors",
+								!isStageActionDisabled
+									? "text-green-500 hover:text-green-400 hover:bg-green-500/10"
+									: "text-gray-600 cursor-not-allowed opacity-50",
+							)}
+							disabled={isStageActionDisabled}
+							onClick={onBooking}
+						>
+							<Calendar className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{!isSameSource && selectedCount > 0 ? disabledReason : "Booking"}
+					</TooltipContent>
+				</Tooltip>
 
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								className="text-gray-400 hover:text-white hover:bg-white/5 h-8 w-8"
-								disabled={isStageActionDisabled}
-								onClick={onArchive}
-							>
-								<Archive className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{!isSameSource && selectedCount > 0 ? disabledReason : "Archive"}
-						</TooltipContent>
-					</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className="text-gray-400 hover:text-white hover:bg-white/5 h-8 w-8"
+							disabled={isStageActionDisabled}
+							onClick={onArchive}
+						>
+							<Archive className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{!isSameSource && selectedCount > 0 ? disabledReason : "Archive"}
+					</TooltipContent>
+				</Tooltip>
 
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								onClick={onSendToCallList}
-								disabled={isStageActionDisabled}
-								className="text-orange-500/80 hover:text-orange-500 hover:bg-orange-500/10 h-8 w-8"
-							>
-								<Phone className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{!isSameSource && selectedCount > 0
-								? disabledReason
-								: "Send to Call List"}
-						</TooltipContent>
-					</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							onClick={onSendToCallList}
+							disabled={isStageActionDisabled}
+							className="text-orange-500/80 hover:text-orange-500 hover:bg-orange-500/10 h-8 w-8"
+						>
+							<Phone className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{!isSameSource && selectedCount > 0
+							? disabledReason
+							: "Send to Call List"}
+					</TooltipContent>
+				</Tooltip>
 
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								className={cn(
-									"h-8 w-8 transition-colors",
-									!isStageActionDisabled
-										? "text-orange-500/80 hover:text-orange-500 hover:bg-orange-500/10"
-										: "text-gray-600 cursor-not-allowed opacity-50",
-								)}
-								disabled={isStageActionDisabled}
-								onClick={onReorder}
-							>
-								<RotateCcw className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{!isSameSource && selectedCount > 0 ? disabledReason : "Reorder"}
-						</TooltipContent>
-					</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className={cn(
+								"h-8 w-8 transition-colors",
+								!isStageActionDisabled
+									? "text-orange-500/80 hover:text-orange-500 hover:bg-orange-500/10"
+									: "text-gray-600 cursor-not-allowed opacity-50",
+							)}
+							disabled={isStageActionDisabled}
+							onClick={onReorder}
+						>
+							<RotateCcw className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{!isSameSource && selectedCount > 0 ? disabledReason : "Reorder"}
+					</TooltipContent>
+				</Tooltip>
 
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								className="text-gray-400 hover:text-white hover:bg-white/5 h-8 w-8"
-								onClick={onExtract}
-							>
-								<Download className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Extract</TooltipContent>
-					</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className="text-gray-400 hover:text-white hover:bg-white/5 h-8 w-8"
+							onClick={onExtract}
+						>
+							<Download className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Extract</TooltipContent>
+				</Tooltip>
 
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								className={cn(
-									"h-8 w-8 transition-colors",
-									showFilters
-										? "bg-white/10 text-white"
-										: "text-gray-400 hover:text-white hover:bg-white/5",
-								)}
-								onClick={onFilterToggle}
-							>
-								<Filter className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Filter</TooltipContent>
-					</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className={cn(
+								"h-8 w-8 transition-colors",
+								showFilters
+									? "bg-white/10 text-white"
+									: "text-gray-400 hover:text-white hover:bg-white/5",
+							)}
+							onClick={onFilterToggle}
+						>
+							<Filter className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Filter</TooltipContent>
+				</Tooltip>
 
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										type="button"
-										variant="ghost"
-										size="icon"
-										className="text-gray-400 hover:text-white hover:bg-white/5 h-8 w-8"
-										disabled={isStageActionDisabled}
-									>
-										<CheckCircle className="h-4 w-4" />
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent
-									align="end"
-									className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon"
+									className="text-gray-400 hover:text-white hover:bg-white/5 h-8 w-8"
+									disabled={isStageActionDisabled}
 								>
-									{partStatuses?.map((status) => {
-										const isHex =
-											status.color?.startsWith("#") ||
-											status.color?.startsWith("rgb");
-										const dotStyle = isHex
-											? { backgroundColor: status.color }
-											: undefined;
-										const colorClass = isHex ? "" : status.color;
-
-										return (
-											<DropdownMenuItem
-												key={status.id}
-												onClick={() => onUpdateStatus?.(status.label)}
-												className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
-											>
-												<div
-													className={cn("w-2 h-2 rounded-full", colorClass)}
-													style={dotStyle}
-												/>
-												<span
-													className="text-xs font-semibold"
-													style={isHex ? { color: status.color } : undefined}
-												>
-													{status.label}
-												</span>
-											</DropdownMenuItem>
-										);
-									})}
-								</DropdownMenuContent>
-							</DropdownMenu>
-						</TooltipTrigger>
-						<TooltipContent>
-							{!isSameSource && selectedCount > 0
-								? disabledReason
-								: "Update Status"}
-						</TooltipContent>
-					</Tooltip>
-				</div>
-
-				<div className="flex items-center gap-2">
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								size="icon"
-								variant="ghost"
-								className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
-								onClick={onDelete}
-								disabled={isStageActionDisabled}
+									<CheckCircle className="h-4 w-4" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								align="end"
+								className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
 							>
-								<Trash2 className="h-4 w-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{!isSameSource && selectedCount > 0 ? disabledReason : "Delete"}
-						</TooltipContent>
-					</Tooltip>
-				</div>
+								{partStatuses?.map((status) => {
+									const isHex =
+										status.color?.startsWith("#") ||
+										status.color?.startsWith("rgb");
+									const dotStyle = isHex
+										? { backgroundColor: status.color }
+										: undefined;
+									const colorClass = isHex ? "" : status.color;
+
+									return (
+										<DropdownMenuItem
+											key={status.id}
+											onClick={() => onUpdateStatus?.(status.label)}
+											className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
+										>
+											<div
+												className={cn("w-2 h-2 rounded-full", colorClass)}
+												style={dotStyle}
+											/>
+											<span
+												className="text-xs font-semibold"
+												style={isHex ? { color: status.color } : undefined}
+											>
+												{status.label}
+											</span>
+										</DropdownMenuItem>
+									);
+								})}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</TooltipTrigger>
+					<TooltipContent>
+						{!isSameSource && selectedCount > 0
+							? disabledReason
+							: "Update Status"}
+					</TooltipContent>
+				</Tooltip>
 			</div>
-		</TooltipProvider>
+
+			<div className="flex items-center gap-2">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							size="icon"
+							variant="ghost"
+							className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
+							onClick={onDelete}
+							disabled={isStageActionDisabled}
+						>
+							<Trash2 className="h-4 w-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{!isSameSource && selectedCount > 0 ? disabledReason : "Delete"}
+					</TooltipContent>
+				</Tooltip>
+			</div>
+		</div>
 	);
 };

--- a/src/components/shared/settings/StatusManagementSection.tsx
+++ b/src/components/shared/settings/StatusManagementSection.tsx
@@ -7,7 +7,6 @@ import { Input } from "@/components/ui/input";
 import {
 	Tooltip,
 	TooltipContent,
-	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -223,36 +222,34 @@ export const StatusManagementSection = ({
 											<Pencil className="h-4 w-4" />
 										</Button>
 
-										<TooltipProvider>
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<span>
-														<Button
-															variant="ghost"
-															size="icon"
-															onClick={() => onRemove(status.id)}
-															disabled={isLocked || !isDeletable}
-															className={cn(
-																"h-9 w-9 rounded-xl transition-all",
-																!isDeletable
-																	? "text-gray-600 cursor-not-allowed"
-																	: "text-gray-500 hover:text-red-400 hover:bg-red-400/10",
-															)}
-														>
-															<Trash2 className="h-4 w-4" />
-														</Button>
-													</span>
-												</TooltipTrigger>
-												{!isDeletable && (
-													<TooltipContent>
-														<p>
-															Cannot delete: Currently used by {usageCount} item
-															{usageCount !== 1 ? "s" : ""}
-														</p>
-													</TooltipContent>
-												)}
-											</Tooltip>
-										</TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span>
+													<Button
+														variant="ghost"
+														size="icon"
+														onClick={() => onRemove(status.id)}
+														disabled={isLocked || !isDeletable}
+														className={cn(
+															"h-9 w-9 rounded-xl transition-all",
+															!isDeletable
+																? "text-gray-600 cursor-not-allowed"
+																: "text-gray-500 hover:text-red-400 hover:bg-red-400/10",
+														)}
+													>
+														<Trash2 className="h-4 w-4" />
+													</Button>
+												</span>
+											</TooltipTrigger>
+											{!isDeletable && (
+												<TooltipContent>
+													<p>
+														Cannot delete: Currently used by {usageCount} item
+														{usageCount !== 1 ? "s" : ""}
+													</p>
+												</TooltipContent>
+											)}
+										</Tooltip>
 									</div>
 								)}
 							</div>


### PR DESCRIPTION
…ooltipProvider" crash

Root cause: `TooltipProvider` was mounted piecemeal across 7 subtrees; any `<Tooltip>` rendered outside those subtrees (OrderFormModal, grid cell renderers, etc.) threw `'Tooltip' must be used within 'TooltipProvider'`, bubbling to the global error screen.

Fix: add a single `<TooltipProvider>` inside `QueryProvider` (the existing global client boundary) so every route, modal portal, and grid cell always has a provider ancestor. Remove the now-redundant nested wrappers from all 7 previous sites.