### PR TITLE
chore: remove unused local exports (knip pass 1)

### DIFF
--- a/src/components/shared/headerNotificationPolling.ts
+++ b/src/components/shared/headerNotificationPolling.ts
@@ -1,8 +1,8 @@
 export const NOTIFICATION_CHECK_INTERVAL_MS = 10_000;
 export const NOTIFICATION_INITIAL_DELAY_MS = 3_000;
-export const NOTIFICATION_FRESHNESS_WINDOW_MS = 8_000;
+const NOTIFICATION_FRESHNESS_WINDOW_MS = 8_000;
 
-export interface NotificationPollingState {
+interface NotificationPollingState {
 	dataVersion: number;
 	lastRunAt: number;
 }

--- a/src/components/shared/search/searchUtils.ts
+++ b/src/components/shared/search/searchUtils.ts
@@ -1,7 +1,7 @@
 import type { PendingRow } from "@/types";
 
 // Global search corpus. Keep in sync with PendingRow.
-export const SEARCH_FIELDS: (keyof PendingRow)[] = [
+const SEARCH_FIELDS: (keyof PendingRow)[] = [
 	"sourceType",
 	"vin",
 	"customerName",

--- a/src/hooks/queries/useQuickTemplatesQuery.ts
+++ b/src/hooks/queries/useQuickTemplatesQuery.ts
@@ -6,7 +6,7 @@ import {
 	type TemplateCategory,
 } from "@/services/quickTemplatesService";
 
-export function quickTemplatesQueryKey(category: TemplateCategory) {
+function quickTemplatesQueryKey(category: TemplateCategory) {
 	return ["quickTemplates", category] as const;
 }
 

--- a/src/hooks/useSessionStatus.ts
+++ b/src/hooks/useSessionStatus.ts
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { authClient } from "@/lib/auth-client";
 
-export type SessionStatus = "active" | "expiringSoon" | "expired" | "absent";
+type SessionStatus = "active" | "expiringSoon" | "expired" | "absent";
 
 interface SessionStatusResult {
 	status: SessionStatus;

--- a/src/lib/attachment.ts
+++ b/src/lib/attachment.ts
@@ -1,7 +1,7 @@
 import { env } from "./env";
 
 type AttachmentKind = "image-pdf" | "link";
-export interface AttachmentValue {
+interface AttachmentValue {
 	attachmentLink?: string;
 	attachmentFilePath?: string;
 	attachmentFilePaths?: string[];

--- a/src/services/orderRepository.ts
+++ b/src/services/orderRepository.ts
@@ -7,6 +7,7 @@ import { supabase as supabaseDefault } from "@/lib/supabase";
 import type {
 	DescriptionConflictResult,
 	DuplicateCheckResult,
+	OrderStage,
 	PendingRow,
 } from "@/types";
 import { mapSupabaseOrder } from "./orderMapper";
@@ -15,8 +16,6 @@ import {
 	isMissingAttachmentColumnError,
 	ServiceError,
 } from "./orderServiceErrors";
-
-export type OrderStage = "orders" | "main" | "call" | "booking" | "archive";
 
 const ORDERS_SELECT_BASE = `
 	id,


### PR DESCRIPTION
Remove export keyword from 8 symbols across 6 files that are never imported externally. Pure structural cleanup, no behavior change.