### PR TITLE
security: enable RLS on all public tables and fix function search_path

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,7 @@
 # Ensures all staged files are linted and formatted before commit.
 
 # Get staged files that Biome can handle
-STAGED_FILES=$(git diff --name-only --cached --diff-filter=ACMR | grep -E '\.(js|jsx|mjs|cjs|ts|tsx|json|css)$')
+STAGED_FILES=$(git diff --name-only --cached --diff-filter=ACMR | grep -E '\.(js|jsx|mjs|cjs|ts|tsx|json|css)$' || true)
 
 if [ -z "$STAGED_FILES" ]; then
     printf '✨ Biome: No files to check, skipping.\n'

--- a/supabase/migrations/20260623_enable_rls_and_fix_security.sql
+++ b/supabase/migrations/20260623_enable_rls_and_fix_security.sql
@@ -1,0 +1,36 @@
+-- Enable RLS on all tables that were previously exposed without it.
+-- App uses service_role_key and Better Auth direct pg — both bypass RLS.
+-- No policies needed; PostgREST access is intentionally blocked for anon/authenticated.
+
+ALTER TABLE public.orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.order_notes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.order_attachments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.order_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.order_reminders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bookings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.report_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.auth_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.auth_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.auth_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.auth_verifications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rate_limits ENABLE ROW LEVEL SECURITY;
+
+-- Drop dead "Enable all access for all users" policies — these were never active
+-- (RLS was off) and would grant anon full access if left in place.
+DROP POLICY IF EXISTS "Enable all access for all users" ON public.orders;
+DROP POLICY IF EXISTS "Enable all access for all users" ON public.order_notes;
+DROP POLICY IF EXISTS "Enable all access for all users" ON public.order_attachments;
+DROP POLICY IF EXISTS "Enable all access for all users" ON public.order_links;
+DROP POLICY IF EXISTS "Enable all access for all users" ON public.order_reminders;
+DROP POLICY IF EXISTS "Enable all access for all users" ON public.bookings;
+DROP POLICY IF EXISTS "Enable all access for all users" ON public.report_settings;
+
+-- Revoke anon/authenticated execute on SECURITY DEFINER function.
+REVOKE EXECUTE ON FUNCTION public.get_database_size_bytes() FROM anon, authenticated;
+
+-- Lock search_path on all affected functions to prevent search_path injection.
+ALTER FUNCTION public.get_database_size_bytes() SET search_path = public;
+ALTER FUNCTION public.fn_log_order_activity_v2() SET search_path = public;
+ALTER FUNCTION public.fn_log_order_activity_v5() SET search_path = public;
+ALTER FUNCTION public.check_rate_limit(p_ip text, p_max_requests integer) SET search_path = public;
+ALTER FUNCTION public.prune_rate_limits() SET search_path = public;


### PR DESCRIPTION
- Enable RLS on 12 tables that were fully exposed to the anon key via PostgREST
- Drop dead "Enable all access for all users" policies (were never active, would grant anon full access once RLS was turned on)
- Revoke anon/authenticated EXECUTE on get_database_size_bytes (SECURITY DEFINER)
- Lock search_path on 5 functions to prevent search_path injection
- Fix pre-commit hook: grep exits 1 on no matches, causing hook to fail for non-JS files

App is unaffected: service_role_key and Better Auth direct pg both bypass RLS.