### PR TITLE
Restrict Orders tab printing to Pending/Reserve statuses

### DIFF
--- a/src/app/(app)/orders/useOrdersPageHandlers.ts
+++ b/src/app/(app)/orders/useOrdersPageHandlers.ts
@@ -7,6 +7,7 @@ import type { FormData } from "@/components/orders/form";
 import { normalizeMileageAsNumber } from "@/domain/order/mileage";
 import {
 	appendTaggedUserNote,
+	filterPrintableRows,
 	filterReservedRows,
 	getEffectiveNoteHistory,
 	getSelectedIds,
@@ -396,7 +397,11 @@ export const useOrdersPageHandlers = () => {
 
 	const handlePrint = () => {
 		if (selectedRows.length === 0) return;
-		printOrderDocument(selectedRows);
+
+		const printableRows = filterPrintableRows(selectedRows, partStatuses);
+		if (printableRows.length === 0) return;
+
+		printOrderDocument(printableRows);
 	};
 
 	const handleReserve = () => {

--- a/src/domain/order/orderWorkflow.ts
+++ b/src/domain/order/orderWorkflow.ts
@@ -383,3 +383,24 @@ export function filterReservedRows(
 		(r) => (r.status ?? "").trim().toLowerCase() === normalized,
 	);
 }
+
+/**
+ * Filters a selection of rows to only those whose `status` matches the
+ * configured "Pending" (`id === "no_stats"`) or "Reserve" (`id === "reserve"`)
+ * part-status labels. Only these statuses are printable via the Print
+ * action — any other status (Hold, Arrived, custom statuses, etc.) is
+ * excluded. Comparison is trim + case-insensitive so label renames are
+ * handled transparently.
+ */
+export function filterPrintableRows(
+	rows: PendingRow[],
+	partStatuses: { id: string; label: string }[],
+): PendingRow[] {
+	const printableLabels = partStatuses
+		.filter((s) => s.id === "no_stats" || s.id === "reserve")
+		.map((s) => s.label.trim().toLowerCase());
+	if (printableLabels.length === 0) return [];
+	return rows.filter((r) =>
+		printableLabels.includes((r.status ?? "").trim().toLowerCase()),
+	);
+}

--- a/src/test/orderWorkflow.test.ts
+++ b/src/test/orderWorkflow.test.ts
@@ -3,6 +3,7 @@ import {
 	appendTaggedUserNote,
 	BLANK_VIN_BUCKET,
 	checkVinPartDuplicate,
+	filterPrintableRows,
 	filterReservedRows,
 	findSameOrderDuplicateIndices,
 	findSameOrderDuplicates,
@@ -836,5 +837,75 @@ describe("filterReservedRows", () => {
 
 	it("returns an empty array for an empty row list", () => {
 		expect(filterReservedRows([], defaultPartStatuses)).toEqual([]);
+	});
+});
+
+describe("filterPrintableRows", () => {
+	const defaultPartStatuses = [
+		{ id: "no_stats", label: "Pending" },
+		{ id: "reserve", label: "Reserve" },
+		{ id: "arrived", label: "Arrived" },
+		{ id: "hold", label: "Hold" },
+	];
+
+	it("returns only Pending/Reserve rows from a mixed selection", () => {
+		const rows = [
+			createMockRow({ id: "1", status: "Pending" }),
+			createMockRow({ id: "2", status: "Reserve" }),
+			createMockRow({ id: "3", status: "Arrived" }),
+			createMockRow({ id: "4", status: "Hold" }),
+		];
+		const result = filterPrintableRows(rows, defaultPartStatuses);
+		expect(result.map((r) => r.id)).toEqual(["1", "2"]);
+	});
+
+	it("is case-insensitive and trim-tolerant", () => {
+		const rows = [
+			createMockRow({ id: "1", status: "  pending  " }),
+			createMockRow({ id: "2", status: "RESERVE" }),
+		];
+		const result = filterPrintableRows(rows, defaultPartStatuses);
+		expect(result.map((r) => r.id)).toEqual(["1", "2"]);
+	});
+
+	it("matches renamed Pending/Reserve labels via id", () => {
+		const renamedStatuses = [
+			{ id: "no_stats", label: "Awaiting Parts" },
+			{ id: "reserve", label: "Reserved" },
+			{ id: "arrived", label: "Arrived" },
+		];
+		const rows = [
+			createMockRow({ id: "1", status: "Awaiting Parts" }),
+			createMockRow({ id: "2", status: "Reserved" }),
+			createMockRow({ id: "3", status: "Arrived" }),
+		];
+		const result = filterPrintableRows(rows, renamedStatuses);
+		expect(result.map((r) => r.id)).toEqual(["1", "2"]);
+	});
+
+	it("excludes custom statuses", () => {
+		const statusesWithCustom = [
+			...defaultPartStatuses,
+			{ id: "custom-1", label: "Backordered" },
+		];
+		const rows = [
+			createMockRow({ id: "1", status: "Backordered" }),
+			createMockRow({ id: "2", status: "Pending" }),
+		];
+		const result = filterPrintableRows(rows, statusesWithCustom);
+		expect(result.map((r) => r.id)).toEqual(["2"]);
+	});
+
+	it("returns an empty array when neither Pending nor Reserve is defined", () => {
+		const noPrintableStatuses = [
+			{ id: "arrived", label: "Arrived" },
+			{ id: "hold", label: "Hold" },
+		];
+		const row = createMockRow({ id: "1", status: "Arrived" });
+		expect(filterPrintableRows([row], noPrintableStatuses)).toEqual([]);
+	});
+
+	it("returns an empty array for an empty row list", () => {
+		expect(filterPrintableRows([], defaultPartStatuses)).toEqual([]);
 	});
 });


### PR DESCRIPTION
Print previously sent every selected row regardless of status. Add filterPrintableRows (mirroring the existing filterReservedRows pattern) so handlePrint silently drops any non-Pending/Reserve rows from the selection before generating the print document.