### PR TITLE
Include Reorder status in Orders print filter

### DIFF
--- a/src/domain/order/orderWorkflow.ts
+++ b/src/domain/order/orderWorkflow.ts
@@ -387,10 +387,10 @@ export function filterReservedRows(
 /**
  * Filters a selection of rows to only those whose `status` matches the
  * configured "Pending" (`id === "no_stats"`) or "Reserve" (`id === "reserve"`)
- * part-status labels. Only these statuses are printable via the Print
- * action — any other status (Hold, Arrived, custom statuses, etc.) is
- * excluded. Comparison is trim + case-insensitive so label renames are
- * handled transparently.
+ * part-status labels, or the literal "Reorder" workflow marker. Only these
+ * statuses are printable via the Print action — any other status (Hold,
+ * Arrived, custom statuses, etc.) is excluded. Comparison is trim and
+ * case-insensitive so label renames are handled transparently.
  */
 export function filterPrintableRows(
 	rows: PendingRow[],
@@ -399,8 +399,8 @@ export function filterPrintableRows(
 	const printableLabels = partStatuses
 		.filter((s) => s.id === "no_stats" || s.id === "reserve")
 		.map((s) => s.label.trim().toLowerCase());
-	if (printableLabels.length === 0) return [];
-	return rows.filter((r) =>
-		printableLabels.includes((r.status ?? "").trim().toLowerCase()),
-	);
+	return rows.filter((r) => {
+		const status = (r.status ?? "").trim().toLowerCase();
+		return status === "reorder" || printableLabels.includes(status);
+	});
 }

--- a/src/test/orderWorkflow.test.ts
+++ b/src/test/orderWorkflow.test.ts
@@ -868,6 +868,38 @@ describe("filterPrintableRows", () => {
 		expect(result.map((r) => r.id)).toEqual(["1", "2"]);
 	});
 
+	it("includes Reorder rows alongside Pending/Reserve", () => {
+		const rows = [
+			createMockRow({ id: "1", status: "Pending" }),
+			createMockRow({ id: "2", status: "Reorder" }),
+			createMockRow({ id: "3", status: "Arrived" }),
+		];
+		const result = filterPrintableRows(rows, defaultPartStatuses);
+		expect(result.map((r) => r.id)).toEqual(["1", "2"]);
+	});
+
+	it("matches Reorder case-insensitively and is trim-tolerant", () => {
+		const rows = [
+			createMockRow({ id: "1", status: "REORDER" }),
+			createMockRow({ id: "2", status: "  reorder  " }),
+		];
+		const result = filterPrintableRows(rows, defaultPartStatuses);
+		expect(result.map((r) => r.id)).toEqual(["1", "2"]);
+	});
+
+	it("includes Reorder rows even when Pending/Reserve are not defined", () => {
+		const noPrintableStatuses = [
+			{ id: "arrived", label: "Arrived" },
+			{ id: "hold", label: "Hold" },
+		];
+		const rows = [
+			createMockRow({ id: "1", status: "Reorder" }),
+			createMockRow({ id: "2", status: "Arrived" }),
+		];
+		const result = filterPrintableRows(rows, noPrintableStatuses);
+		expect(result.map((r) => r.id)).toEqual(["1"]);
+	});
+
 	it("matches renamed Pending/Reserve labels via id", () => {
 		const renamedStatuses = [
 			{ id: "no_stats", label: "Awaiting Parts" },

--- a/src/test/orderWorkflow.test.ts
+++ b/src/test/orderWorkflow.test.ts
@@ -915,6 +915,21 @@ describe("filterPrintableRows", () => {
 		expect(result.map((r) => r.id)).toEqual(["1", "2"]);
 	});
 
+	it("matches Reorder alongside renamed Pending/Reserve labels", () => {
+		const renamedStatuses = [
+			{ id: "no_stats", label: "Awaiting Parts" },
+			{ id: "reserve", label: "Reserved" },
+			{ id: "arrived", label: "Arrived" },
+		];
+		const rows = [
+			createMockRow({ id: "1", status: "  REORDER  " }),
+			createMockRow({ id: "2", status: "Awaiting Parts" }),
+			createMockRow({ id: "3", status: "Arrived" }),
+		];
+		const result = filterPrintableRows(rows, renamedStatuses);
+		expect(result.map((r) => r.id)).toEqual(["1", "2"]);
+	});
+
 	it("excludes custom statuses", () => {
 		const statusesWithCustom = [
 			...defaultPartStatuses,


### PR DESCRIPTION
## Summary
- `filterPrintableRows` (`src/domain/order/orderWorkflow.ts`) only whitelisted rows whose status matched the user-configurable Pending/Reserve `partStatuses` labels, so rows carrying the literal `"Reorder"` workflow marker (set by `buildReorderCommands`) could never be included when printing all selected Orders.
- Added a direct, case-insensitive check for `"reorder"` alongside the existing Pending/Reserve label matching, mirroring the string-literal pattern already used in `StatusRenderer.tsx` for badge rendering.
- Extended `filterPrintableRows` test coverage with Reorder-specific cases (exact match, case/whitespace tolerance, and behavior when Pending/Reserve aren't configured).

Fixes MAH-34.

## Test plan
- [x] `npm run lint` — clean on changed files
- [x] `npm run type-check` — passes
- [x] `npm run test` — `orderWorkflow.test.ts` passes (100/100); 8 pre-existing failures in unrelated files (`useWarrantyExpiryMaintenance.test.ts` etc.) confirmed present on `main` before this change, unaffected by this diff
- [x] `npm run build` — compiles and type-checks successfully; page-data collection fails only due to missing Supabase/DB env vars in this sandbox (no `.env.local` provisioned), unrelated to this change


---
_Generated by [Claude Code](https://claude.ai/code/session_0153SwAfqj8m3cCRXyJC3eFG)_