### PR TITLE
fix(MAH-18): Phase 3 — Foundational Error Handling (route PostgrestError + null-column guards)

### DIFF
--- a/src/services/appSettingsService.ts
+++ b/src/services/appSettingsService.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/lib/supabase";
+import { handleSupabaseError } from "@/services/orderServiceErrors";
 
 export interface AppSettings {
 	models: string[];
@@ -13,11 +14,11 @@ export const appSettingsService = {
 			.select("models, repair_systems, requesters")
 			.eq("id", 1)
 			.single();
-		if (error) throw error;
+		if (error) handleSupabaseError(error);
 		return {
-			models: data.models as string[],
-			repairSystems: data.repair_systems as string[],
-			requesters: data.requesters as string[],
+			models: (data.models as string[] | null) ?? [],
+			repairSystems: (data.repair_systems as string[] | null) ?? [],
+			requesters: (data.requesters as string[] | null) ?? [],
 		};
 	},
 

--- a/src/test/appSettingsService.test.ts
+++ b/src/test/appSettingsService.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type AppSettings,
+	appSettingsService,
+} from "@/services/appSettingsService";
+import { ServiceError } from "@/services/orderServiceErrors";
+
+// ── Supabase module mock ──────────────────────────────────────────────────────
+// appSettingsService uses the module-level `supabase` singleton, so we mock the
+// entire module. The `single` function is the leaf of the query chain and is
+// the only one that needs to return a resolved value.
+
+const mockSingle = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({
+	supabase: {
+		from: vi.fn(() => ({
+			select: vi.fn(() => ({
+				eq: vi.fn(() => ({
+					single: mockSingle,
+				})),
+			})),
+		})),
+	},
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("appSettingsService.fetchAppSettings", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// ── MAH-18 fix (1): typed error path ─────────────────────────────────────
+	describe("error handling — routes PostgrestError through handleSupabaseError", () => {
+		it("throws a ServiceError (not the raw PostgrestError) when Supabase returns an error", async () => {
+			const postgrestError = {
+				code: "PGRST301",
+				message: "Row not found",
+				details: "The row with id=1 does not exist",
+				hint: null,
+			};
+
+			mockSingle.mockResolvedValueOnce({ data: null, error: postgrestError });
+
+			await expect(
+				appSettingsService.fetchAppSettings(),
+			).rejects.toBeInstanceOf(ServiceError);
+		});
+
+		it("surfaces the original error message inside the ServiceError", async () => {
+			const postgrestError = {
+				code: "57014",
+				message: "statement timeout",
+				details: null,
+				hint: null,
+			};
+
+			mockSingle.mockResolvedValueOnce({ data: null, error: postgrestError });
+
+			await expect(appSettingsService.fetchAppSettings()).rejects.toThrow(
+				"statement timeout",
+			);
+		});
+
+		it("carries the Supabase error code on the ServiceError", async () => {
+			const postgrestError = {
+				code: "23505",
+				message: "duplicate key value violates unique constraint",
+				details: null,
+				hint: null,
+			};
+
+			mockSingle.mockResolvedValueOnce({ data: null, error: postgrestError });
+
+			let caught: unknown;
+			try {
+				await appSettingsService.fetchAppSettings();
+			} catch (err) {
+				caught = err;
+			}
+
+			expect(caught).toBeInstanceOf(ServiceError);
+			expect((caught as ServiceError).code).toBe("23505");
+		});
+
+		it("does NOT throw the raw PostgrestError object directly", async () => {
+			const postgrestError = {
+				code: "42P01",
+				message: "relation does not exist",
+				details: null,
+				hint: null,
+			};
+
+			mockSingle.mockResolvedValueOnce({ data: null, error: postgrestError });
+
+			let caught: unknown;
+			try {
+				await appSettingsService.fetchAppSettings();
+			} catch (err) {
+				caught = err;
+			}
+
+			// The raw PostgrestError is a plain object, not an Error instance.
+			// Before the fix, `throw error` would propagate that plain object.
+			// After the fix, only a ServiceError (which extends Error) is thrown.
+			expect(caught).toBeInstanceOf(Error);
+			expect(caught).not.toEqual(postgrestError);
+		});
+	});
+
+	// ── MAH-18 fix (2): ?? [] guards on nullable array columns ───────────────
+	describe("null-column guards — defaults NULL DB columns to empty arrays", () => {
+		it("returns [] for models when the DB column is NULL", async () => {
+			mockSingle.mockResolvedValueOnce({
+				data: {
+					models: null,
+					repair_systems: ["Mechanical"],
+					requesters: ["Sales"],
+				},
+				error: null,
+			});
+
+			const result: AppSettings = await appSettingsService.fetchAppSettings();
+
+			expect(result.models).toEqual([]);
+		});
+
+		it("returns [] for repairSystems when the DB column is NULL", async () => {
+			mockSingle.mockResolvedValueOnce({
+				data: {
+					models: ["Megane"],
+					repair_systems: null,
+					requesters: ["Sales"],
+				},
+				error: null,
+			});
+
+			const result: AppSettings = await appSettingsService.fetchAppSettings();
+
+			expect(result.repairSystems).toEqual([]);
+		});
+
+		it("returns [] for requesters when the DB column is NULL", async () => {
+			mockSingle.mockResolvedValueOnce({
+				data: {
+					models: ["Megane"],
+					repair_systems: ["Mechanical"],
+					requesters: null,
+				},
+				error: null,
+			});
+
+			const result: AppSettings = await appSettingsService.fetchAppSettings();
+
+			expect(result.requesters).toEqual([]);
+		});
+
+		it("returns [] for all three columns when all are NULL", async () => {
+			mockSingle.mockResolvedValueOnce({
+				data: { models: null, repair_systems: null, requesters: null },
+				error: null,
+			});
+
+			const result: AppSettings = await appSettingsService.fetchAppSettings();
+
+			expect(result.models).toEqual([]);
+			expect(result.repairSystems).toEqual([]);
+			expect(result.requesters).toEqual([]);
+		});
+	});
+
+	// ── Happy path ────────────────────────────────────────────────────────────
+	describe("successful fetch — returns correctly shaped AppSettings", () => {
+		it("maps snake_case DB columns to camelCase AppSettings fields", async () => {
+			const dbRow = {
+				models: ["Renault Megane", "Dacia Duster"],
+				repair_systems: ["Mechanical", "Electrical"],
+				requesters: ["Sales", "Warranty"],
+			};
+
+			mockSingle.mockResolvedValueOnce({ data: dbRow, error: null });
+
+			const result: AppSettings = await appSettingsService.fetchAppSettings();
+
+			expect(result).toEqual<AppSettings>({
+				models: ["Renault Megane", "Dacia Duster"],
+				repairSystems: ["Mechanical", "Electrical"],
+				requesters: ["Sales", "Warranty"],
+			});
+		});
+
+		it("returns empty arrays when all columns are present but empty", async () => {
+			mockSingle.mockResolvedValueOnce({
+				data: { models: [], repair_systems: [], requesters: [] },
+				error: null,
+			});
+
+			const result: AppSettings = await appSettingsService.fetchAppSettings();
+
+			expect(result.models).toEqual([]);
+			expect(result.repairSystems).toEqual([]);
+			expect(result.requesters).toEqual([]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes **MAH-18** from the *Phase 3 — Foundational Error Handling* milestone.

## Problem

ppSettingsService.fetchAppSettings had two bugs:

1. **Raw error propagation**: if (error) throw error threw the plain PostgrestError object directly, bypassing the typed handleSupabaseError path used everywhere else in the codebase. Callers received an untyped object instead of a ServiceError.

2. **Nullable column casts without guards**: data.models as string[] (and epair_systems, equesters) did not account for NULL DB values. If any column is NULL, callers doing .includes()/.map() on the result crash at runtime. mobileOrderService.ts already guards these same columns with ?? [], confirming null is a real possible state.

## Changes

### src/services/appSettingsService.ts
- Import handleSupabaseError from orderServiceErrors
- if (error) handleSupabaseError(error) — routes through the typed error path
- (data.models as string[] | null) ?? [] — applied to all three array columns

### src/test/appSettingsService.test.ts *(new)*
- 10 focused unit tests covering:
  - Error routing: throws ServiceError, not raw PostgrestError; preserves message and error code
  - Null guards: each of the three columns individually, and all three simultaneously
  - Happy path: correct camelCase mapping and empty-array handling

## Quality Gates
- ✅ 
pm run type-check — no errors
- ✅ 
px biome check (changed files) — no errors
- ✅ itest run src/test/appSettingsService.test.ts — 10/10 pass

Closes MAH-18