### PR TITLE
Create isolated QueryClient per provider mount instead of singleton

### DIFF
--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -2,17 +2,13 @@
 
 import { QueryClientProvider } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { queryClient } from "@/lib/queryClient";
+import { createAppQueryClient } from "@/lib/queryClient";
 import {
 	createReactQueryAdapter,
 	setOrdersQueryAdapter,
 } from "@/store/ordersQueryAdapter";
-
-// Register the React Query–backed adapter synchronously at module load so the
-// first store action (which may run before any component mounts) already sees
-// it. See architecture-audit.md H1.
-setOrdersQueryAdapter(createReactQueryAdapter(queryClient));
 
 const Devtools =
 	process.env.NODE_ENV === "development"
@@ -30,6 +26,20 @@ export default function QueryProvider({
 }: {
 	children: React.ReactNode;
 }) {
+	// One isolated QueryClient per provider mount (per request/session). The
+	// `useState` initializer stays pure — creating the client only — so React's
+	// StrictMode double-invoke never registers a client that gets discarded.
+	const [queryClient] = useState(() => createAppQueryClient());
+
+	// Register the React Query–backed adapter so the Zustand notification store
+	// reads through the *live* client bound to this provider. This runs on mount,
+	// well before Header's first notification check (deferred ~3s), so
+	// `checkNotifications` never sees a stale/undefined adapter. See
+	// architecture-audit.md H1.
+	useEffect(() => {
+		setOrdersQueryAdapter(createReactQueryAdapter(queryClient));
+	}, [queryClient]);
+
 	return (
 		<QueryClientProvider client={queryClient}>
 			<TooltipProvider>{children}</TooltipProvider>

--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { createAppQueryClient } from "@/lib/queryClient";
 import {
+	clearOrdersQueryAdapter,
 	createReactQueryAdapter,
 	setOrdersQueryAdapter,
 } from "@/store/ordersQueryAdapter";
@@ -34,10 +35,15 @@ export default function QueryProvider({
 	// Register the React Query–backed adapter so the Zustand notification store
 	// reads through the *live* client bound to this provider. This runs on mount,
 	// well before Header's first notification check (deferred ~3s), so
-	// `checkNotifications` never sees a stale/undefined adapter. See
-	// architecture-audit.md H1.
+	// `checkNotifications` never sees a stale/undefined adapter. The cleanup keeps
+	// registration symmetric across mount/unmount and StrictMode's dev-only
+	// setup->cleanup->setup replay, so the counter never falsely reports a double
+	// registration. See architecture-audit.md H1.
 	useEffect(() => {
 		setOrdersQueryAdapter(createReactQueryAdapter(queryClient));
+		return () => {
+			clearOrdersQueryAdapter();
+		};
 	}, [queryClient]);
 
 	return (

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -6,15 +6,28 @@ export const getOrdersQueryKey = (stage: OrderStage) =>
 
 export const DASHBOARD_STATS_QUERY_KEY = ["dashboard-stats"] as const;
 
-export const queryClient = new QueryClient({
-	defaultOptions: {
-		queries: {
-			staleTime: 1000 * 60 * 5,
-			gcTime: 1000 * 60 * 10,
-			retry: 1,
-			refetchOnWindowFocus: false,
-			refetchOnReconnect: true,
-			retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
+/**
+ * Creates a fresh, isolated `QueryClient`.
+ *
+ * A new instance is created per `QueryProvider` mount (see
+ * `src/components/providers/QueryProvider.tsx`) rather than exporting a
+ * module-level singleton. In the Next.js App Router a module-level cache is
+ * shared across every incoming server request, so a singleton would leak one
+ * user's cached query data into another request once server-side prefetching is
+ * introduced. Keeping creation in a factory gives each request/session an
+ * isolated cache.
+ */
+export function createAppQueryClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: {
+				staleTime: 1000 * 60 * 5,
+				gcTime: 1000 * 60 * 10,
+				retry: 1,
+				refetchOnWindowFocus: false,
+				refetchOnReconnect: true,
+				retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
+			},
 		},
-	},
-});
+	});
+}

--- a/src/store/ordersQueryAdapter.ts
+++ b/src/store/ordersQueryAdapter.ts
@@ -46,6 +46,21 @@ export function setOrdersQueryAdapter(adapter: OrdersQueryAdapter): void {
 	registered = adapter;
 }
 
+/**
+ * Tears down the current registration, restoring the no-op default.
+ *
+ * Paired with `setOrdersQueryAdapter` as the cleanup half of a React effect so
+ * the registration is symmetric across mount/unmount. This also keeps
+ * `registrationCount` balanced under React StrictMode, which double-invokes
+ * effects (setup -> cleanup -> setup) on mount in development — without the
+ * decrement here that dev-only replay would falsely trip the
+ * "registered more than once" warning below.
+ */
+export function clearOrdersQueryAdapter(): void {
+	registrationCount = Math.max(0, registrationCount - 1);
+	registered = noopAdapter;
+}
+
 export function getOrdersQueryAdapter(): OrdersQueryAdapter {
 	return registered;
 }

--- a/src/test/Header.notificationPolling.test.tsx
+++ b/src/test/Header.notificationPolling.test.tsx
@@ -5,7 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Header } from "@/components/shared/Header";
 import { shouldRunNotificationCheck } from "@/components/shared/headerNotificationPolling";
 import type { OrderStage } from "@/domain/order/orderStage";
-import { getOrdersQueryKey, queryClient } from "@/lib/queryClient";
+import { getOrdersQueryKey } from "@/lib/queryClient";
+import { queryClient } from "./testQueryClient";
 
 function renderHeader() {
 	return render(

--- a/src/test/QueryProvider.test.tsx
+++ b/src/test/QueryProvider.test.tsx
@@ -1,0 +1,119 @@
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import QueryProvider from "@/components/providers/QueryProvider";
+import { getOrdersQueryKey } from "@/lib/queryClient";
+import { useAppStore } from "@/store/useStore";
+import type { PendingRow } from "@/types";
+
+// `QueryProvider` reaches for `next/dynamic` (devtools) which is a no-op here
+// because NODE_ENV !== "development" in the test runner.
+
+/**
+ * Renders `<QueryProvider>` and hands back the isolated `QueryClient` that the
+ * provider created for this mount (captured via the React Query context, i.e.
+ * the exact instance bound to `<QueryClientProvider>`).
+ */
+function renderProviderAndCaptureClient() {
+	let captured: QueryClient | undefined;
+
+	function Probe() {
+		captured = useQueryClient();
+		return null;
+	}
+
+	const utils = render(
+		<QueryProvider>
+			<Probe />
+		</QueryProvider>,
+	);
+
+	if (!captured) {
+		throw new Error("QueryProvider did not expose a QueryClient");
+	}
+	return { client: captured, ...utils };
+}
+
+const makeReminderRow = (id: string): PendingRow => ({
+	id,
+	baseId: `B${id}`,
+	trackingId: `T${id}`,
+	customerName: "Test User",
+	vin: `VIN${id}`,
+	mobile: "123",
+	cntrRdg: 1000,
+	model: "Test",
+	parts: [],
+	sabNumber: "S1",
+	acceptedBy: "User",
+	requester: "User",
+	partNumber: "P1",
+	description: "Desc",
+	quantity: 1,
+	status: "Orders",
+	rDate: "2024-01-01",
+	repairSystem: "None",
+	startWarranty: "",
+	endWarranty: "",
+	remainTime: "",
+	reminder: { date: "2026-03-01", time: "10:00", subject: "Call customer" },
+});
+
+describe("QueryProvider", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		// Reset the persisted store's notification state between tests.
+		useAppStore.setState({
+			notifications: [],
+			dismissedManagedNotificationKeys: {},
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("creates a fresh, isolated QueryClient per mount (no shared singleton)", () => {
+		// AC #1 / #5: two independent provider trees — standing in for two
+		// separate browser sessions — must never share a query cache.
+		const first = renderProviderAndCaptureClient();
+		const second = renderProviderAndCaptureClient();
+
+		expect(first.client).toBeDefined();
+		expect(second.client).toBeDefined();
+		expect(first.client).not.toBe(second.client);
+
+		// Data written into one client is invisible to the other.
+		first.client.setQueryData(getOrdersQueryKey("orders"), [
+			makeReminderRow("1"),
+		]);
+		expect(
+			second.client.getQueryData(getOrdersQueryKey("orders")),
+		).toBeUndefined();
+	});
+
+	it("registers the adapter against the provider's live client so checkNotifications reads it", () => {
+		// AC #2 / #3: mounting the provider wires `setOrdersQueryAdapter` to the
+		// client it created; the store then reads live data through that adapter.
+		vi.setSystemTime(new Date("2026-06-01T12:00:00.000Z"));
+
+		const { client } = renderProviderAndCaptureClient();
+
+		// Seed the live client the provider is bound to (not a stale singleton).
+		client.setQueryData(getOrdersQueryKey("orders"), [makeReminderRow("1")]);
+		client.setQueryData(getOrdersQueryKey("main"), []);
+		client.setQueryData(getOrdersQueryKey("booking"), []);
+		client.setQueryData(getOrdersQueryKey("call"), []);
+
+		act(() => {
+			useAppStore.getState().checkNotifications();
+		});
+
+		const reminders = useAppStore
+			.getState()
+			.notifications.filter((n) => n.type === "reminder");
+		expect(reminders).toHaveLength(1);
+		expect(reminders[0]?.referenceId).toBe("1");
+	});
+});

--- a/src/test/QueryProvider.test.tsx
+++ b/src/test/QueryProvider.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import QueryProvider from "@/components/providers/QueryProvider";
 import { getOrdersQueryKey } from "@/lib/queryClient";
+import { getOrdersQueryAdapter } from "@/store/ordersQueryAdapter";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
 
@@ -115,5 +116,20 @@ describe("QueryProvider", () => {
 			.notifications.filter((n) => n.type === "reminder");
 		expect(reminders).toHaveLength(1);
 		expect(reminders[0]?.referenceId).toBe("1");
+	});
+
+	it("tears down the adapter on unmount so registration stays symmetric", () => {
+		// Regression guard: the adapter registration must be paired with a cleanup
+		// so React StrictMode's dev-only setup->cleanup->setup replay cannot leave
+		// the registration counter imbalanced (which would trip a false
+		// "registered more than once" warning). After unmount the live adapter is
+		// gone and reads fall back to the no-op default.
+		const { client, unmount } = renderProviderAndCaptureClient();
+		client.setQueryData(getOrdersQueryKey("orders"), [makeReminderRow("1")]);
+		expect(getOrdersQueryAdapter().getStageRows("orders")).toHaveLength(1);
+
+		unmount();
+
+		expect(getOrdersQueryAdapter().getStageRows("orders")).toBeUndefined();
 	});
 });

--- a/src/test/draftSessionSlice.test.ts
+++ b/src/test/draftSessionSlice.test.ts
@@ -11,10 +11,11 @@ vi.mock("sonner", () => ({
 
 import type { OrderStage } from "@/domain/order/orderStage";
 import { ORDER_STAGES } from "@/lib/constants";
-import { getOrdersQueryKey, queryClient } from "@/lib/queryClient";
+import { getOrdersQueryKey } from "@/lib/queryClient";
 import type { DraftRecoverySnapshot } from "@/store/slices/draftSessionSlice";
 import { useAppStore } from "@/store/useStore";
 import type { PatchRowCommand, PendingRow } from "@/types";
+import { queryClient } from "./testQueryClient";
 
 const EMPTY_BASELINE: Record<OrderStage, PendingRow[]> = {
 	orders: [],

--- a/src/test/notificationSlice.test.ts
+++ b/src/test/notificationSlice.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
-import { getOrdersQueryKey, queryClient } from "@/lib/queryClient";
+import { getOrdersQueryKey } from "@/lib/queryClient";
 import { createNotificationSlice } from "../store/slices/notificationSlice";
 import type { CombinedStore } from "../store/types";
 import type { PendingRow } from "../types";
+import { queryClient } from "./testQueryClient";
 
 // Mock orderService
 vi.mock("@/services/orderService", () => ({

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -15,10 +15,10 @@ process.env.RESEND_FROM_EMAIL = "test@example.com";
 // already use via `queryClient.setQueryData(...)`. Without this, store slices
 // (which now go through the adapter) would see the no-op default instead of
 // the seeded data. See h1-plan.md step 3.
-import { queryClient } from "@/lib/queryClient";
 import {
 	createReactQueryAdapter,
 	setOrdersQueryAdapter,
 } from "@/store/ordersQueryAdapter";
+import { queryClient } from "./testQueryClient";
 
 setOrdersQueryAdapter(createReactQueryAdapter(queryClient));

--- a/src/test/testQueryClient.ts
+++ b/src/test/testQueryClient.ts
@@ -1,0 +1,12 @@
+import { createAppQueryClient } from "@/lib/queryClient";
+
+/**
+ * Shared QueryClient for the test suite.
+ *
+ * Production no longer exports a module-level `queryClient` singleton (each
+ * `QueryProvider` mount owns an isolated client — see MAH-38). Tests still need
+ * a single client they can seed via `queryClient.setQueryData(...)` and that the
+ * `OrdersQueryAdapter` (wired in `test/setup.ts`) reads from. This module
+ * provides exactly that, built with the same config factory as production.
+ */
+export const queryClient = createAppQueryClient();


### PR DESCRIPTION
## Summary

Refactors the React Query setup to create a fresh, isolated `QueryClient` for each `QueryProvider` mount instead of exporting a module-level singleton. This prevents query cache leakage across server requests in the Next.js App Router and ensures each session/request has its own isolated cache.

## Key Changes

- **`src/lib/queryClient.ts`**: Converted the module-level `queryClient` singleton into a `createAppQueryClient()` factory function that returns a new `QueryClient` with the same configuration. Added documentation explaining why isolation is necessary for server-side prefetching.

- **`src/components/providers/QueryProvider.tsx`**: 
  - Now creates a fresh `QueryClient` per mount using `useState(() => createAppQueryClient())`
  - Moved adapter registration from module load into a `useEffect` hook that runs on mount
  - Added cleanup function (`clearOrdersQueryAdapter()`) to tear down the adapter on unmount, keeping registration symmetric across mount/unmount and React StrictMode's dev-only setup→cleanup→setup replay

- **`src/store/ordersQueryAdapter.ts`**: Added `clearOrdersQueryAdapter()` function to restore the no-op default adapter and decrement the registration counter, paired with `setOrdersQueryAdapter()` as the cleanup half of the effect.

- **`src/test/testQueryClient.ts`** (new): Created a shared test-only `QueryClient` built from the same factory, allowing tests to seed data via `setQueryData()` while the adapter (wired in `test/setup.ts`) reads from it.

- **Test files updated**: `Header.notificationPolling.test.tsx`, `draftSessionSlice.test.ts`, `notificationSlice.test.ts`, and `setup.ts` now import `queryClient` from `test/testQueryClient.ts` instead of `lib/queryClient.ts`.

- **`src/test/QueryProvider.test.tsx`** (new): Comprehensive test suite verifying:
  - Each provider mount creates an isolated client (no shared singleton)
  - The adapter is registered against the live client so notifications read current data
  - The adapter is properly torn down on unmount (symmetric registration)

## Implementation Details

The adapter registration is now deferred to a `useEffect` that runs after the component mounts, ensuring it happens well before the Header's first notification check (~3s delay). The cleanup function keeps the registration counter balanced under React StrictMode's dev-only double-invoke, preventing false "registered more than once" warnings. This design maintains the architecture requirement (H1 in architecture-audit.md) that the Zustand notification store reads through the live React Query client bound to the current provider instance.

https://claude.ai/code/session_01FAR7LcGV2CdYTHyvPwaNxu