### PR TITLE
fix: Phase 2 database & query performance (MAH-42, MAH-43)

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -38,23 +38,15 @@ const DistributionChart = dynamic(
 );
 
 export default function DashboardPage() {
-	const { data: statsData = [], isLoading: isStageLoading } =
+	const { data: statsData, isLoading: isStageLoading } =
 		useDashboardStatsQuery();
 
-	const ordersCount = statsData.filter((row) => row.stage === "orders").length;
-	const mainCount = statsData.filter((row) => row.stage === "main").length;
-	const bookingCount = statsData.filter(
-		(row) => row.stage === "booking",
-	).length;
-	const archiveCount = statsData.filter(
-		(row) => row.stage === "archive",
-	).length;
-
-	const callQueueRows = statsData.filter((row) => row.stage === "call");
-	const callCount = callQueueRows.length;
-	const callUniqueVehicles = new Set(
-		callQueueRows.map((item) => item.vin).filter(Boolean),
-	).size;
+	const ordersCount = statsData?.orders ?? 0;
+	const mainCount = statsData?.main ?? 0;
+	const bookingCount = statsData?.booking ?? 0;
+	const archiveCount = statsData?.archive ?? 0;
+	const callCount = statsData?.call ?? 0;
+	const callUniqueVehicles = statsData?.callUniqueVehicles ?? 0;
 
 	// Memoize stats to prevent recalculation
 	const stats = useMemo(

--- a/src/hooks/queries/useDashboardStatsQuery.ts
+++ b/src/hooks/queries/useDashboardStatsQuery.ts
@@ -1,24 +1,15 @@
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
-import type { OrderStage } from "@/domain/order/orderStage";
 import { DASHBOARD_STATS_QUERY_KEY } from "@/lib/queryClient";
 import { orderService } from "@/services/orderService";
-
-interface DashboardStatRow {
-	id: string;
-	vin: string | null;
-	stage: OrderStage | null;
-}
+import type { OrderStageCounts } from "@/types";
 
 export function useDashboardStatsQuery(): UseQueryResult<
-	DashboardStatRow[],
+	OrderStageCounts,
 	Error
 > {
-	return useQuery<DashboardStatRow[]>({
+	return useQuery<OrderStageCounts>({
 		queryKey: DASHBOARD_STATS_QUERY_KEY,
-		queryFn: async (): Promise<DashboardStatRow[]> => {
-			const data = await orderService.getDashboardStats();
-			return (data || []) as DashboardStatRow[];
-		},
+		queryFn: (): Promise<OrderStageCounts> => orderService.getDashboardStats(),
 		staleTime: 1000 * 60 * 5, // 5 minutes
 		gcTime: 1000 * 60 * 10, // 10 minutes
 	});

--- a/src/services/mobileOrderService.ts
+++ b/src/services/mobileOrderService.ts
@@ -54,47 +54,56 @@ export const mobileOrderService = {
 		const rowsToInsert =
 			parts.length === 0 ? [{ partNumber: "", description: "" }] : parts;
 
-		const errors: string[] = [];
-
-		const results = await Promise.allSettled(
-			rowsToInsert.map((part) => {
-				const partId = crypto.randomUUID();
-				const partEntry = {
-					id: partId,
+		const rows = rowsToInsert.map((part) => {
+			const partId = crypto.randomUUID();
+			const partEntry = {
+				id: partId,
+				partNumber: part.partNumber,
+				description: part.description,
+			};
+			return {
+				...sharedIdentity,
+				stage: "orders",
+				metadata: {
+					...sharedMetadata,
+					parts: [partEntry],
 					partNumber: part.partNumber,
 					description: part.description,
-				};
-				const row = {
-					...sharedIdentity,
-					stage: "orders",
-					metadata: {
-						...sharedMetadata,
-						parts: [partEntry],
-						partNumber: part.partNumber,
-						description: part.description,
-					},
-				};
-				return supabase.from("orders").insert([row]).select().single();
-			}),
-		);
+				},
+			};
+		});
 
-		for (const result of results) {
-			if (result.status === "fulfilled" && result.value.error) {
-				logger.error(
-					"[mobile-order] insert error:",
-					result.value.error.message,
-				);
-				errors.push(result.value.error.message);
-			} else if (result.status === "rejected") {
-				const msg =
-					result.reason instanceof Error
-						? result.reason.message
-						: String(result.reason);
-				logger.error("[mobile-order] insert error:", msg);
-				errors.push(msg);
+		const errors: string[] = [];
+
+		try {
+			const { data, error } = await supabase.rpc("insert_orders_bulk", {
+				p_rows: rows,
+			});
+
+			if (error) {
+				logger.error("[mobile-order] bulk insert error:", error.message);
+				return { inserted: 0, errors: rows.map(() => error.message) };
 			}
-		}
 
-		return { inserted: rowsToInsert.length - errors.length, errors };
+			const results = (data ?? []) as Array<{
+				idx: number;
+				success: boolean;
+				error_message: string | null;
+			}>;
+
+			for (const result of results) {
+				if (!result.success) {
+					const msg = result.error_message ?? "Unknown insert error";
+					logger.error("[mobile-order] insert error:", msg);
+					errors.push(msg);
+				}
+			}
+
+			return { inserted: rows.length - errors.length, errors };
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			logger.error("[mobile-order] insert error:", msg);
+			return { inserted: 0, errors: rows.map(() => msg) };
+		}
 	},
 };

--- a/src/services/mobileOrderService.ts
+++ b/src/services/mobileOrderService.ts
@@ -91,15 +91,27 @@ export const mobileOrderService = {
 				error_message: string | null;
 			}>;
 
+			let inserted = 0;
 			for (const result of results) {
-				if (!result.success) {
+				if (result.success) {
+					inserted++;
+				} else {
 					const msg = result.error_message ?? "Unknown insert error";
 					logger.error("[mobile-order] insert error:", msg);
 					errors.push(msg);
 				}
 			}
 
-			return { inserted: rows.length - errors.length, errors };
+			// A missing/short/malformed result set (fewer rows than submitted, with
+			// no top-level error) must not be reported as full success.
+			const missing = rows.length - results.length;
+			if (missing > 0) {
+				const msg = "No result returned for row";
+				logger.error("[mobile-order] insert error:", msg);
+				for (let i = 0; i < missing; i++) errors.push(msg);
+			}
+
+			return { inserted, errors };
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
 			logger.error("[mobile-order] insert error:", msg);

--- a/src/services/order/orderQueryRepository.ts
+++ b/src/services/order/orderQueryRepository.ts
@@ -5,6 +5,7 @@ import type {
 	DescriptionConflictResult,
 	DuplicateCheckResult,
 	OrderStage,
+	OrderStageCounts,
 	PendingRow,
 } from "@/types";
 import { mapSupabaseOrder } from "../orderMapper";
@@ -126,18 +127,32 @@ export function createOrderQueryRepository(
 			}
 		},
 
-		async getDashboardStats() {
-			// `.order("id")` gives the pagination loop a stable window; the rows
-			// are only counted (unordered), so this has no UI impact.
-			const { data, error } = await fetchAllPages<{
-				id: string;
-				vin: string | null;
-				stage: string | null;
-			}>((from, to) =>
-				db.from("orders").select("id, vin, stage").order("id").range(from, to),
-			);
+		async getDashboardStats(): Promise<OrderStageCounts> {
+			const { data, error } = await db.rpc("get_order_stage_counts");
 			if (error) handleSupabaseError(error);
-			return data;
+
+			const counts: OrderStageCounts = {
+				orders: 0,
+				main: 0,
+				call: 0,
+				booking: 0,
+				archive: 0,
+				callUniqueVehicles: 0,
+			};
+
+			for (const row of data ?? []) {
+				const stage = row.stage as OrderStage | null;
+				if (stage && stage in counts) {
+					counts[
+						stage as Exclude<keyof OrderStageCounts, "callUniqueVehicles">
+					] = Number(row.row_count) || 0;
+				}
+				if (stage === "call") {
+					counts.callUniqueVehicles = Number(row.call_unique_vehicles) || 0;
+				}
+			}
+
+			return counts;
 		},
 
 		async checkHistoricalVinPartDuplicate(

--- a/src/test/api/mobile-order.route.test.ts
+++ b/src/test/api/mobile-order.route.test.ts
@@ -1,20 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// We test the handler logic by mocking Supabase inserts and the rate-limit RPC.
-// The handler is imported after mocks are set up.
+// We test the handler logic by mocking the Supabase RPC calls (rate limiting
+// and the bulk insert) rather than the old per-row insert() chain — the
+// service now issues a single `insert_orders_bulk` RPC call instead of N
+// separate `.insert().select().single()` calls (MAH-43).
 
-const mockInsert = vi.fn();
-const mockSelect = vi.fn();
-const mockSingle = vi.fn();
-// mockRpc simulates the check_rate_limit / prune_rate_limits RPCs.
-// Default: not rate-limited.
-const mockRpc = vi.fn().mockResolvedValue({ data: false, error: null });
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs a flexible shape for multiple RPC responses
+let rateLimitResponse: any = { data: false, error: null };
+// biome-ignore lint/suspicious/noExplicitAny: null means "auto-generate an all-success response from p_rows"
+let bulkInsertResponse: any = null;
+
+const mockRpc = vi.fn((fn: string, args?: Record<string, unknown>) => {
+	if (fn === "check_rate_limit") {
+		return Promise.resolve(rateLimitResponse);
+	}
+	if (fn === "insert_orders_bulk") {
+		if (bulkInsertResponse) return Promise.resolve(bulkInsertResponse);
+		const rows = (args?.p_rows ?? []) as unknown[];
+		return Promise.resolve({
+			data: rows.map((_, i) => ({
+				idx: i,
+				success: true,
+				error_message: null,
+			})),
+			error: null,
+		});
+	}
+	// prune_rate_limits and any other fire-and-forget RPCs
+	return Promise.resolve({ data: null, error: null });
+});
 
 // biome-ignore lint/suspicious/noExplicitAny: test mock needs flexible return type for multi-table mocking
 const mockFrom = vi.fn((_table: string): any => ({
-	insert: mockInsert.mockReturnThis(),
-	select: mockSelect.mockReturnThis(),
-	single: mockSingle,
+	select: vi.fn().mockReturnThis(),
+	eq: vi.fn().mockReturnThis(),
+	single: vi.fn().mockResolvedValue({ data: null, error: { message: "mock" } }),
 }));
 
 vi.mock("@supabase/supabase-js", () => ({
@@ -36,17 +56,19 @@ function makeRequest(body: unknown) {
 	});
 }
 
+function getBulkInsertRows() {
+	const call = mockRpc.mock.calls.find((c) => c[0] === "insert_orders_bulk");
+	// biome-ignore lint/suspicious/noExplicitAny: reading test mock call args
+	return (call?.[1] as any)?.p_rows as Array<Record<string, unknown>>;
+}
+
 describe("POST /api/mobile-order", () => {
 	beforeEach(() => {
 		process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
 		process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
 		vi.clearAllMocks();
-		// Default: not rate-limited
-		mockRpc.mockResolvedValue({ data: false, error: null });
-		mockSingle.mockResolvedValue({
-			data: { id: "uuid-1", stage: "orders" },
-			error: null,
-		});
+		rateLimitResponse = { data: false, error: null };
+		bulkInsertResponse = null;
 	});
 
 	it("returns 400 when company is missing", async () => {
@@ -59,15 +81,20 @@ describe("POST /api/mobile-order", () => {
 		const req = makeRequest({ company: "Zeekr", parts: [] });
 		const res = await POST(req as never);
 		expect(res.status).toBe(200);
-		expect(mockFrom).toHaveBeenCalledWith("orders");
-		expect(mockInsert).toHaveBeenCalledTimes(1);
-		const insertArg = mockInsert.mock.calls[0][0][0];
-		expect(insertArg.stage).toBe("orders");
-		expect(insertArg.metadata.requester).toBe("mobile");
-		expect(insertArg.metadata.status).toBe("Pending");
+		expect(mockRpc).toHaveBeenCalledWith(
+			"insert_orders_bulk",
+			expect.anything(),
+		);
+		const rows = getBulkInsertRows();
+		expect(rows).toHaveLength(1);
+		expect(rows[0].stage).toBe("orders");
+		// biome-ignore lint/suspicious/noExplicitAny: reading test row shape
+		expect((rows[0].metadata as any).requester).toBe("mobile");
+		// biome-ignore lint/suspicious/noExplicitAny: reading test row shape
+		expect((rows[0].metadata as any).status).toBe("Pending");
 	});
 
-	it("inserts N rows for N valid parts", async () => {
+	it("sends N rows in a single bulk insert call for N valid parts", async () => {
 		const req = makeRequest({
 			company: "Renault",
 			parts: [
@@ -77,8 +104,12 @@ describe("POST /api/mobile-order", () => {
 		});
 		const res = await POST(req as never);
 		expect(res.status).toBe(200);
-		// One insert call per part
-		expect(mockInsert).toHaveBeenCalledTimes(2);
+		// Exactly one RPC call for the bulk insert, carrying both rows.
+		const bulkCalls = mockRpc.mock.calls.filter(
+			(c) => c[0] === "insert_orders_bulk",
+		);
+		expect(bulkCalls).toHaveLength(1);
+		expect(getBulkInsertRows()).toHaveLength(2);
 	});
 
 	it("forces requester to 'mobile' regardless of payload", async () => {
@@ -87,17 +118,19 @@ describe("POST /api/mobile-order", () => {
 			parts: [{ partNumber: "X", description: "Y" }],
 		});
 		await POST(req as never);
-		const insertArg = mockInsert.mock.calls[0][0][0];
-		expect(insertArg.metadata.requester).toBe("mobile");
+		const rows = getBulkInsertRows();
+		// biome-ignore lint/suspicious/noExplicitAny: reading test row shape
+		expect((rows[0].metadata as any).requester).toBe("mobile");
 	});
 
 	it("sets rDate to today if not provided", async () => {
 		const req = makeRequest({ company: "Zeekr", parts: [] });
 		await POST(req as never);
-		const insertArg = mockInsert.mock.calls[0][0][0];
-		// rDate stored in metadata
-		expect(typeof insertArg.metadata.rDate).toBe("string");
-		expect(insertArg.metadata.rDate.length).toBeGreaterThan(0);
+		const rows = getBulkInsertRows();
+		// biome-ignore lint/suspicious/noExplicitAny: reading test row shape
+		const rDate = (rows[0].metadata as any).rDate;
+		expect(typeof rDate).toBe("string");
+		expect(rDate.length).toBeGreaterThan(0);
 	});
 
 	it("copies shared identity data onto every row", async () => {
@@ -112,39 +145,47 @@ describe("POST /api/mobile-order", () => {
 			],
 		});
 		await POST(req as never);
-		for (const call of mockInsert.mock.calls) {
-			const row = call[0][0];
+		const rows = getBulkInsertRows();
+		for (const row of rows) {
 			expect(row.customer_name).toBe("Alice");
 			expect(row.vin).toBe("VIN123");
 			expect(row.customer_phone).toBe("0500000001");
 		}
 	});
-});
 
-// Task 4: app_settings merge tests
-const mockAppSettingsSelect = vi.fn().mockResolvedValue({
-	data: { models: ["Megane IV"], repair_systems: ["Mechanical"] },
-	error: null,
-});
-
-mockFrom.mockImplementation((table: string) => {
-	if (table === "app_settings") {
-		return {
-			select: vi.fn().mockReturnValue({
-				eq: vi.fn().mockReturnValue({
-					single: mockAppSettingsSelect,
-				}),
-			}),
-			update: vi.fn().mockReturnValue({
-				eq: vi.fn().mockResolvedValue({ data: {}, error: null }),
-			}),
+	it("reports partial success when some rows fail server-side", async () => {
+		bulkInsertResponse = {
+			data: [
+				{ idx: 0, success: true, error_message: null },
+				{ idx: 1, success: false, error_message: "duplicate key" },
+			],
+			error: null,
 		};
-	}
-	return {
-		insert: mockInsert.mockReturnThis(),
-		select: mockSelect.mockReturnThis(),
-		single: mockSingle,
-	};
+		const req = makeRequest({
+			company: "Renault",
+			parts: [
+				{ partNumber: "A1", description: "Part A" },
+				{ partNumber: "B2", description: "Part B" },
+			],
+		});
+		const res = await POST(req as never);
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.inserted).toBe(1);
+	});
+
+	it("returns 500 when every row in the bulk insert fails", async () => {
+		bulkInsertResponse = {
+			data: [{ idx: 0, success: false, error_message: "insert failed" }],
+			error: null,
+		};
+		const req = makeRequest({
+			company: "Zeekr",
+			parts: [{ partNumber: "A1", description: "Part A" }],
+		});
+		const res = await POST(req as never);
+		expect(res.status).toBe(500);
+	});
 });
 
 describe("POST /api/mobile-order — app_settings", () => {
@@ -152,34 +193,8 @@ describe("POST /api/mobile-order — app_settings", () => {
 		process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
 		process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
 		vi.clearAllMocks();
-		mockRpc.mockResolvedValue({ data: false, error: null });
-		mockSingle.mockResolvedValue({
-			data: { id: "uuid-1", stage: "orders" },
-			error: null,
-		});
-		mockAppSettingsSelect.mockResolvedValue({
-			data: { models: ["Megane IV"], repair_systems: ["Mechanical"] },
-			error: null,
-		});
-		mockFrom.mockImplementation((table: string) => {
-			if (table === "app_settings") {
-				return {
-					select: vi.fn().mockReturnValue({
-						eq: vi.fn().mockReturnValue({
-							single: mockAppSettingsSelect,
-						}),
-					}),
-					update: vi.fn().mockReturnValue({
-						eq: vi.fn().mockResolvedValue({ data: {}, error: null }),
-					}),
-				};
-			}
-			return {
-				insert: mockInsert.mockReturnThis(),
-				select: mockSelect.mockReturnThis(),
-				single: mockSingle,
-			};
-		});
+		rateLimitResponse = { data: false, error: null };
+		bulkInsertResponse = null;
 	});
 
 	it("never reads or writes app_settings for a valid request with a new model", async () => {
@@ -192,7 +207,6 @@ describe("POST /api/mobile-order — app_settings", () => {
 		const res = await POST(req as never);
 		expect(res.status).toBe(200);
 		expect(mockFrom).not.toHaveBeenCalledWith("app_settings");
-		expect(mockAppSettingsSelect).not.toHaveBeenCalled();
 	});
 });
 
@@ -201,11 +215,8 @@ describe("POST /api/mobile-order — payload bounds", () => {
 		process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
 		process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
 		vi.clearAllMocks();
-		mockRpc.mockResolvedValue({ data: false, error: null });
-		mockSingle.mockResolvedValue({
-			data: { id: "uuid-1", stage: "orders" },
-			error: null,
-		});
+		rateLimitResponse = { data: false, error: null };
+		bulkInsertResponse = null;
 	});
 
 	it("returns 400 when model exceeds 80 characters", async () => {
@@ -256,14 +267,11 @@ describe("POST /api/mobile-order — rate limiting", () => {
 		process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
 		process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
 		vi.clearAllMocks();
-		mockSingle.mockResolvedValue({
-			data: { id: "uuid-1", stage: "orders" },
-			error: null,
-		});
+		rateLimitResponse = { data: false, error: null };
+		bulkInsertResponse = null;
 	});
 
 	it("passes the caller IP to the rate-limit RPC", async () => {
-		mockRpc.mockResolvedValue({ data: false, error: null });
 		await POST(makeRequestWithIp("10.0.0.1") as never);
 		expect(mockRpc).toHaveBeenCalledWith(
 			"check_rate_limit",
@@ -275,13 +283,12 @@ describe("POST /api/mobile-order — rate limiting", () => {
 	});
 
 	it("allows request when RPC returns false (under limit)", async () => {
-		mockRpc.mockResolvedValue({ data: false, error: null });
 		const res = await POST(makeRequestWithIp("10.0.0.1") as never);
 		expect(res.status).not.toBe(429);
 	});
 
 	it("returns 429 when RPC returns true (limit reached)", async () => {
-		mockRpc.mockResolvedValue({ data: true, error: null });
+		rateLimitResponse = { data: true, error: null };
 		const res = await POST(makeRequestWithIp("10.0.0.1") as never);
 		expect(res.status).toBe(429);
 		const json = await res.json();
@@ -289,13 +296,12 @@ describe("POST /api/mobile-order — rate limiting", () => {
 	});
 
 	it("fails open (allows request) when RPC errors", async () => {
-		mockRpc.mockResolvedValue({ data: null, error: { message: "DB error" } });
+		rateLimitResponse = { data: null, error: { message: "DB error" } };
 		const res = await POST(makeRequestWithIp("10.0.0.1") as never);
 		expect(res.status).not.toBe(429);
 	});
 
 	it(`passes RATE_LIMIT_MAX (${RATE_LIMIT_MAX}) to the RPC`, async () => {
-		mockRpc.mockResolvedValue({ data: false, error: null });
 		await POST(makeRequestWithIp("10.0.0.1") as never);
 		expect(mockRpc).toHaveBeenCalledWith(
 			"check_rate_limit",

--- a/src/test/mobileOrderService.test.ts
+++ b/src/test/mobileOrderService.test.ts
@@ -168,4 +168,30 @@ describe("mobileOrderService.createOrders", () => {
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0]).toBe("network failure");
 	});
+
+	// ── Test 6: short/malformed result set must not be reported as full success ──
+	it("does not report full success when the RPC returns fewer rows than submitted", async () => {
+		// 3 parts submitted, but the RPC only returns 2 result rows (e.g. a
+		// truncated response) with no top-level error.
+		mockRpc.mockResolvedValueOnce({
+			data: [rpcRow(0, true), rpcRow(1, true)],
+			error: null,
+		});
+
+		const supabase = makeSupabaseStub();
+		const result: CreateOrdersResult = await mobileOrderService.createOrders(
+			supabase,
+			{
+				...baseInput,
+				parts: [
+					{ partNumber: "P1", description: "Part 1" },
+					{ partNumber: "P2", description: "Part 2" },
+					{ partNumber: "P3", description: "Part 3" },
+				],
+			},
+		);
+
+		expect(result.inserted).toBe(2);
+		expect(result.errors).toHaveLength(1);
+	});
 });

--- a/src/test/mobileOrderService.test.ts
+++ b/src/test/mobileOrderService.test.ts
@@ -2,48 +2,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CreateOrdersResult } from "@/services/mobileOrderService";
 import { mobileOrderService } from "@/services/mobileOrderService";
 
-// ── Supabase chain stubs ──────────────────────────────────────────────────────
-// The service accepts a SupabaseClient directly, so we pass a minimal stub
-// rather than mocking the module. Each table branch returns the correct chain:
-//
-//   "app_settings"  →  .select().eq().single()
-//   "orders"        →  .insert([row]).select().single()
-//
-// mergeAppSettings is made a no-op by returning { data: null, error: { message: "mock" } }
-// from the app_settings single().
+// ── Supabase RPC stub ─────────────────────────────────────────────────────────
+// createOrders now issues a single `supabase.rpc("insert_orders_bulk", { p_rows })`
+// call (MAH-43) instead of N per-row `.insert().select().single()` calls. The
+// RPC returns one row per input row: { idx, success, error_message }.
 
-const mockOrderSingle = vi.fn();
-
-const mockAppSettingsSingle = vi.fn().mockResolvedValue({
-	data: null,
-	error: { message: "mock" },
-});
+const mockRpc = vi.fn();
 
 // biome-ignore lint/suspicious/noExplicitAny: test stub must satisfy SupabaseClient shape
 function makeSupabaseStub(): any {
-	const insertChain = {
-		select: vi.fn(() => ({
-			single: mockOrderSingle,
-		})),
-	};
+	return { rpc: mockRpc };
+}
 
-	return {
-		from: vi.fn((table: string) => {
-			if (table === "app_settings") {
-				return {
-					select: vi.fn(() => ({
-						eq: vi.fn(() => ({
-							single: mockAppSettingsSingle,
-						})),
-					})),
-				};
-			}
-			// "orders" table
-			return {
-				insert: vi.fn(() => insertChain),
-			};
-		}),
-	};
+function rpcRow(
+	idx: number,
+	success: boolean,
+	error_message: string | null = null,
+) {
+	return { idx, success, error_message };
 }
 
 // ── Shared base input ─────────────────────────────────────────────────────────
@@ -60,17 +36,12 @@ const baseInput = {
 describe("mobileOrderService.createOrders", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		// Default: app_settings returns error → mergeAppSettings is always a no-op.
-		mockAppSettingsSingle.mockResolvedValue({
-			data: null,
-			error: { message: "mock" },
-		});
 	});
 
 	// ── Test 1: empty-parts fallback ──────────────────────────────────────────
 	it("inserts one blank row when parts is empty", async () => {
-		mockOrderSingle.mockResolvedValueOnce({
-			data: { id: "uuid-blank", stage: "orders" },
+		mockRpc.mockResolvedValueOnce({
+			data: [rpcRow(0, true)],
 			error: null,
 		});
 
@@ -81,22 +52,22 @@ describe("mobileOrderService.createOrders", () => {
 			{ ...baseInput, parts: [] },
 		);
 
-		// Exactly one insert must have been made to the "orders" table.
-		const ordersFrom = supabase.from.mock.calls.filter(
-			(c: string[]) => c[0] === "orders",
+		expect(mockRpc).toHaveBeenCalledTimes(1);
+		expect(mockRpc).toHaveBeenCalledWith(
+			"insert_orders_bulk",
+			expect.objectContaining({
+				p_rows: expect.arrayContaining([
+					expect.objectContaining({
+						metadata: expect.objectContaining({
+							partNumber: "",
+							description: "",
+						}),
+					}),
+				]),
+			}),
 		);
-		expect(ordersFrom).toHaveLength(1);
 
-		// Retrieve the row that was inserted.
-		// biome-ignore lint/suspicious/noExplicitAny: accessing mock internals requires any cast
-		const ordersBuilder = (supabase.from as any).mock.results.find(
-			(_: unknown, i: number) =>
-				// biome-ignore lint/suspicious/noExplicitAny: accessing mock internals requires any cast
-				(supabase.from as any).mock.calls[i][0] === "orders",
-		)?.value;
-		// biome-ignore lint/suspicious/noExplicitAny: accessing mock internals requires any cast
-		const insertedRow = (ordersBuilder.insert as any).mock.calls[0][0][0];
-
+		const insertedRow = mockRpc.mock.calls[0][1].p_rows[0];
 		expect(insertedRow.metadata.partNumber).toBe("");
 		expect(insertedRow.metadata.description).toBe("");
 		expect(insertedRow.metadata.stage).toBeUndefined(); // MAH-26
@@ -109,19 +80,14 @@ describe("mobileOrderService.createOrders", () => {
 	// ── Test 2: partial failure counting ─────────────────────────────────────
 	it("counts only successful inserts and collects errors on partial failure", async () => {
 		// 3 parts: first two succeed, third fails.
-		mockOrderSingle
-			.mockResolvedValueOnce({
-				data: { id: "uuid-1", stage: "orders" },
-				error: null,
-			})
-			.mockResolvedValueOnce({
-				data: { id: "uuid-2", stage: "orders" },
-				error: null,
-			})
-			.mockResolvedValueOnce({
-				data: null,
-				error: { message: "insert failed for part 3" },
-			});
+		mockRpc.mockResolvedValueOnce({
+			data: [
+				rpcRow(0, true),
+				rpcRow(1, true),
+				rpcRow(2, false, "insert failed for part 3"),
+			],
+			error: null,
+		});
 
 		const supabase = makeSupabaseStub();
 
@@ -143,19 +109,17 @@ describe("mobileOrderService.createOrders", () => {
 	});
 
 	// ── Test 3: full success with parts ───────────────────────────────────────
-	it("returns inserted equal to part count and empty errors on full success", async () => {
+	it("sends all parts in a single bulk RPC call and reports full success", async () => {
 		const parts = [
 			{ partNumber: "A1", description: "Brake pad" },
 			{ partNumber: "B2", description: "Air filter" },
 			{ partNumber: "C3", description: "Oil filter" },
 		];
 
-		for (let i = 0; i < parts.length; i++) {
-			mockOrderSingle.mockResolvedValueOnce({
-				data: { id: `uuid-${i}`, stage: "orders" },
-				error: null,
-			});
-		}
+		mockRpc.mockResolvedValueOnce({
+			data: parts.map((_, i) => rpcRow(i, true)),
+			error: null,
+		});
 
 		const supabase = makeSupabaseStub();
 
@@ -164,19 +128,35 @@ describe("mobileOrderService.createOrders", () => {
 			{ ...baseInput, parts },
 		);
 
-		// One "orders" from-call per part.
-		const ordersFromCount = (
-			supabase.from as ReturnType<typeof vi.fn>
-		).mock.calls.filter((c: string[]) => c[0] === "orders").length;
-		expect(ordersFromCount).toBe(parts.length);
+		// Exactly one RPC round trip carrying all rows.
+		expect(mockRpc).toHaveBeenCalledTimes(1);
+		expect(mockRpc.mock.calls[0][1].p_rows).toHaveLength(parts.length);
 
 		expect(result.inserted).toBe(parts.length);
 		expect(result.errors).toHaveLength(0);
 	});
 
-	// ── Test 4: network rejection handling ────────────────────────────────────
-	it("collects errors when insert promise rejects (e.g. network failure)", async () => {
-		mockOrderSingle.mockRejectedValueOnce(new Error("network failure"));
+	// ── Test 4: RPC-level error (e.g. connection failure) ─────────────────────
+	it("collects a shared error per row when the RPC call itself errors", async () => {
+		mockRpc.mockResolvedValueOnce({
+			data: null,
+			error: { message: "connection reset" },
+		});
+
+		const supabase = makeSupabaseStub();
+		const result: CreateOrdersResult = await mobileOrderService.createOrders(
+			supabase,
+			{ ...baseInput, parts: [{ partNumber: "P1", description: "Part 1" }] },
+		);
+
+		expect(result.inserted).toBe(0);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toBe("connection reset");
+	});
+
+	// ── Test 5: network rejection handling ────────────────────────────────────
+	it("collects errors when the RPC call promise rejects (e.g. network failure)", async () => {
+		mockRpc.mockRejectedValueOnce(new Error("network failure"));
 
 		const supabase = makeSupabaseStub();
 		const result: CreateOrdersResult = await mobileOrderService.createOrders(

--- a/src/test/orderService.test.ts
+++ b/src/test/orderService.test.ts
@@ -1151,29 +1151,6 @@ describe("orderService", () => {
 			expect(range).toHaveBeenNthCalledWith(2, 1000, 1999);
 		});
 
-		it("getDashboardStats paginates the same way", async () => {
-			const firstPage = Array.from({ length: 1000 }, (_, i) => ({
-				id: `id-${i}`,
-				vin: null,
-				stage: "main",
-			}));
-			const secondPage = [{ id: "id-1000", vin: null, stage: "call" }];
-			const range = vi.fn((from: number) =>
-				Promise.resolve({
-					data: from === 0 ? firstPage : secondPage,
-					error: null,
-				}),
-			);
-
-			const svc = createOrderQueryRepository(makePagedDb(range));
-			const result = await svc.getDashboardStats();
-
-			expect(result).toHaveLength(1001);
-			expect(range).toHaveBeenCalledTimes(2);
-			expect(range).toHaveBeenNthCalledWith(1, 0, 999);
-			expect(range).toHaveBeenNthCalledWith(2, 1000, 1999);
-		});
-
 		it("getOrders surfaces a non-attachment error via handleSupabaseError", async () => {
 			const range = vi.fn().mockResolvedValue({
 				data: null,
@@ -1191,6 +1168,84 @@ describe("orderService", () => {
 				"statement timeout",
 			);
 			expect(range).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("createOrderQueryRepository – getDashboardStats (MAH-42)", () => {
+		function makeRpcDb(rpc: ReturnType<typeof vi.fn>) {
+			return { rpc } as unknown as Parameters<
+				typeof createOrderQueryRepository
+			>[0];
+		}
+
+		it("calls the get_order_stage_counts RPC instead of paginating rows", async () => {
+			const rpc = vi.fn().mockResolvedValue({
+				data: [
+					{ stage: "orders", row_count: 3, call_unique_vehicles: 0 },
+					{ stage: "main", row_count: 5, call_unique_vehicles: 0 },
+					{ stage: "call", row_count: 4, call_unique_vehicles: 2 },
+					{ stage: "booking", row_count: 1, call_unique_vehicles: 0 },
+					{ stage: "archive", row_count: 7, call_unique_vehicles: 0 },
+				],
+				error: null,
+			});
+
+			const svc = createOrderQueryRepository(makeRpcDb(rpc));
+			const result = await svc.getDashboardStats();
+
+			expect(rpc).toHaveBeenCalledWith("get_order_stage_counts");
+			expect(result).toEqual({
+				orders: 3,
+				main: 5,
+				call: 4,
+				booking: 1,
+				archive: 7,
+				callUniqueVehicles: 2,
+			});
+		});
+
+		it("defaults every stage and callUniqueVehicles to 0 when no rows exist for a stage", async () => {
+			const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+
+			const svc = createOrderQueryRepository(makeRpcDb(rpc));
+			const result = await svc.getDashboardStats();
+
+			expect(result).toEqual({
+				orders: 0,
+				main: 0,
+				call: 0,
+				booking: 0,
+				archive: 0,
+				callUniqueVehicles: 0,
+			});
+		});
+
+		it("defaults to 0 when data is null", async () => {
+			const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+
+			const svc = createOrderQueryRepository(makeRpcDb(rpc));
+			const result = await svc.getDashboardStats();
+
+			expect(result.orders).toBe(0);
+			expect(result.callUniqueVehicles).toBe(0);
+		});
+
+		it("surfaces an RPC error via handleSupabaseError instead of returning stale/partial counts", async () => {
+			const rpc = vi.fn().mockResolvedValue({
+				data: null,
+				error: {
+					code: "500",
+					message: "aggregate query failed",
+					details: null,
+					hint: null,
+				},
+			});
+
+			const svc = createOrderQueryRepository(makeRpcDb(rpc));
+
+			await expect(svc.getDashboardStats()).rejects.toThrow(
+				"aggregate query failed",
+			);
 		});
 	});
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,17 @@ export interface DescriptionConflictResult {
 	existingRow?: PendingRow;
 }
 
+/** Per-stage row counts, computed via SQL aggregation (see get_order_stage_counts RPC). */
+export interface OrderStageCounts {
+	orders: number;
+	main: number;
+	call: number;
+	booking: number;
+	archive: number;
+	/** Distinct VIN count within the "call" stage. */
+	callUniqueVehicles: number;
+}
+
 export interface AppNotification {
 	id: string;
 	type: "reminder" | "warranty" | "booking_followup" | "cntr_rdg_warning";

--- a/supabase/migrations/20260711_add_get_order_stage_counts.sql
+++ b/supabase/migrations/20260711_add_get_order_stage_counts.sql
@@ -1,0 +1,30 @@
+-- Migration: Create get_order_stage_counts() RPC
+-- Returns per-stage row counts plus the distinct VIN count within the "call"
+-- stage in a single aggregate query, replacing the dashboard's previous
+-- approach of fetching every row's id/vin/stage and counting client-side.
+--
+-- NULLIF(vin, '') before COUNT(DISTINCT ...) reproduces the client's prior
+-- `.filter(Boolean)` semantics exactly: NULL vins are already excluded by
+-- COUNT(DISTINCT), and NULLIF additionally drops empty-string vins so the
+-- aggregate matches the old client-computed value for every input.
+
+CREATE OR REPLACE FUNCTION public.get_order_stage_counts()
+RETURNS TABLE(stage text, row_count bigint, call_unique_vehicles bigint)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    stage,
+    COUNT(*) AS row_count,
+    COUNT(DISTINCT NULLIF(vin, '')) FILTER (WHERE stage = 'call')
+      AS call_unique_vehicles
+  FROM public.orders
+  GROUP BY stage;
+$$;
+
+-- The dashboard reads this over the anon client (same exposure level as the
+-- existing full-row orders select it replaces, but with far less data).
+REVOKE EXECUTE ON FUNCTION public.get_order_stage_counts() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_order_stage_counts()
+  TO anon, authenticated, service_role;

--- a/supabase/migrations/20260711_add_insert_orders_bulk.sql
+++ b/supabase/migrations/20260711_add_insert_orders_bulk.sql
@@ -23,7 +23,7 @@ BEGIN
         r->>'customer_phone',
         r->>'vin',
         r->>'company',
-        r->>'stage',
+        (r->>'stage')::public.order_stage,
         (r->'metadata')::jsonb
       );
       idx := i;

--- a/supabase/migrations/20260711_add_insert_orders_bulk.sql
+++ b/supabase/migrations/20260711_add_insert_orders_bulk.sql
@@ -1,0 +1,48 @@
+-- Migration: Create insert_orders_bulk() RPC
+-- Bulk-inserts mobile order-intake rows in a single round trip while still
+-- reporting per-row success/failure, preserving the mobile intake service's
+-- existing partial-success UX (previously achieved via N separate
+-- Promise.allSettled single-row inserts).
+
+CREATE OR REPLACE FUNCTION public.insert_orders_bulk(p_rows jsonb)
+RETURNS TABLE(idx int, success boolean, error_message text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  r jsonb;
+  i int := 0;
+BEGIN
+  FOR r IN SELECT * FROM jsonb_array_elements(p_rows) LOOP
+    BEGIN
+      INSERT INTO public.orders
+        (customer_name, customer_phone, vin, company, stage, metadata)
+      VALUES (
+        r->>'customer_name',
+        r->>'customer_phone',
+        r->>'vin',
+        r->>'company',
+        r->>'stage',
+        (r->'metadata')::jsonb
+      );
+      idx := i;
+      success := true;
+      error_message := null;
+      RETURN NEXT;
+    EXCEPTION WHEN OTHERS THEN
+      idx := i;
+      success := false;
+      error_message := SQLERRM;
+      RETURN NEXT;
+    END;
+    i := i + 1;
+  END LOOP;
+END;
+$$;
+
+-- Called only via the service-role client already used by /api/mobile-order —
+-- no anon/authenticated grant needed.
+REVOKE EXECUTE ON FUNCTION public.insert_orders_bulk(jsonb) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.insert_orders_bulk(jsonb) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.insert_orders_bulk(jsonb) TO service_role;


### PR DESCRIPTION
## Summary

Implements the Phase 2 — Database & Query Performance Linear milestone, scoped to **MAH-42** and **MAH-43**. **MAH-41 is intentionally not implemented** — see "Scope decision" below.

- **MAH-42** — Dashboard stage counts (`getDashboardStats`) previously fetched every order row's `id`/`vin`/`stage` via `fetchAllPages` and counted stages client-side. Replaced with a `get_order_stage_counts()` SQL aggregation RPC (mirrors the existing `get_database_size_bytes()` / `get_storage_size_bytes()` pattern) returning per-stage counts plus `call_unique_vehicles` in one query.
- **MAH-43** — Mobile order intake (`mobileOrderService.createOrders`) previously issued N parallel single-row inserts via `Promise.allSettled` (one HTTP round trip per part). Replaced with a single `insert_orders_bulk()` RPC call that inserts all rows in one round trip while still reporting per-row success/failure.

## MAH-43 partial-success decision (explicit, per AC)

Chose the **RPC-preserving-partial-success** approach over a plain `insert(rows)`. A plain bulk insert is all-or-nothing — one invalid row would fail the entire multi-part submission, which is a real behavior regression for mobile intake (a typo in part 3 shouldn't lose parts 1–2). `insert_orders_bulk()` loops server-side with a per-row `EXCEPTION` block, so the existing `{ inserted, errors }` contract and UX are unchanged — verified by both the service unit tests and the route-level tests (`insert_orders_bulk` call site, `p_rows` shape, partial-failure and all-fail cases).

## Before / after (analytical — no live large dataset available this session, see below)

- **Dashboard:** N page-fetches (1000 rows/page via `fetchAllPages`) transferring every row's `id`/`vin`/`stage` → **1** aggregate query transferring 5 summary rows. Payload and round-trip count both drop from O(rows) to O(1).
- **Mobile intake (K parts):** K sequential-per-part HTTP round trips (`Promise.allSettled` over K `insert().select().single()` calls) → **1** HTTP round trip carrying all K rows. Latency drops from O(K) round trips to O(1).

## MAH-41 — scope decision (not implemented)

MAH-41 asks for true server-side pagination so the client never loads a full stage's rows. Doing that properly means moving the `archive` view off AG Grid's client-side row model, which conflicts with several existing archive features that assume the *full* dataset is in memory: the draft-session (`useDraftSession("archive")` undo/redo over `workingRows`), `VINLineCounter`, `SelectAllByVinButton`, and CSV export. Reworking all four is a larger, UI-behavior-affecting change that belongs in its own reviewed PR, not folded into this query-performance fix.

A design (AG Grid Infinite Row Model + keyset pagination on `(created_at desc, id asc)` to avoid dup/skip under concurrent writes, server-side VIN aggregates, opt-in full-fetch CSV export, and an open question on draft-session semantics) was posted as a Linear comment on MAH-41. Per explicit direction, MAH-41 was **canceled** in Linear rather than left pending, since implementing it here risked breaking those archive features.

## Test plan

- [x] `npm run test` — 650/650 tests pass, including new RPC-based tests for `getDashboardStats` (empty data, null data, RPC error, exact-count mapping) and rewritten tests for `mobileOrderService.createOrders` / `POST /api/mobile-order` (bulk RPC call shape, partial success, all-fail, network rejection)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — no new errors (2 pre-existing `noBannedTypes` warnings in `orderService.test.ts`, confirmed present on `main` before this change, untouched by this PR)
- [x] `npm run build` — compiles and type-checks successfully; static page-data collection fails in this sandbox only because there's no `.env.local` (`DATABASE_URL`, Supabase keys, etc.) — confirmed identical failure on unmodified `main` in this same environment, so it's an environment limitation, not a regression from this change
- [ ] **Migrations must be applied to Supabase before merge/deploy** — `supabase/migrations/20260711_add_get_order_stage_counts.sql` and `supabase/migrations/20260711_add_insert_orders_bulk.sql` were not run against a live database (no Supabase connection available in this session); both RPCs must exist before this code path is exercised in production
- [ ] Live large-dataset before/after numbers (dashboard load time, mobile intake latency) — pending a populated environment; the reasoning above is payload/round-trip-count based, not measured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013ANR7cVwQDpw4hwY8X3DoC)_