### PR TITLE
Phase 3: State Management & Realtime Sync (MAH-39, MAH-40)

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { logger } from "@/lib/logger";
+import { createNotificationCandidatesRepository } from "@/services/notifications/notificationCandidatesRepository";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+	const session = await auth.api.getSession({ headers: req.headers });
+	if (!session?.user?.id)
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+	try {
+		const repository = createNotificationCandidatesRepository();
+		const candidates = await repository.getDueNotificationCandidates();
+		return NextResponse.json({ candidates });
+	} catch (error: unknown) {
+		const message =
+			error instanceof Error ? error.message : "Internal server error";
+		logger.error("[notifications GET]", message);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500 },
+		);
+	}
+}

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -21,6 +21,7 @@ import {
 	type AllowedCompany,
 } from "@/domain/order/constants";
 import type { OrderStage } from "@/domain/order/orderStage";
+import { useNotificationCandidatesQuery } from "@/hooks/queries/useNotificationCandidatesQuery";
 import { useDraftSession } from "@/hooks/useDraftSession";
 import { useRecentSearches } from "@/hooks/useRecentSearches";
 import { useWarrantyExpiryMaintenance } from "@/hooks/useWarrantyExpiryMaintenance";
@@ -60,6 +61,7 @@ export const Header = React.memo(function Header() {
 
 	const checkNotifications = useAppStore((state) => state.checkNotifications);
 	const { runMaintenance } = useWarrantyExpiryMaintenance();
+	useNotificationCandidatesQuery();
 	const searchTerm = useAppStore((state) => state.searchTerm);
 	const setSearchTerm = useAppStore((state) => state.setSearchTerm);
 	const [searchInput, setSearchInput] = useState(searchTerm);

--- a/src/hooks/queries/useBulkDeleteOrdersMutation.ts
+++ b/src/hooks/queries/useBulkDeleteOrdersMutation.ts
@@ -11,6 +11,7 @@ import {
 import {
 	DASHBOARD_STATS_QUERY_KEY,
 	getOrdersQueryKey,
+	NOTIFICATION_CANDIDATES_QUERY_KEY,
 } from "@/lib/queryClient";
 import { orderService } from "@/services/orderService";
 import type { PendingRow } from "@/types";
@@ -65,6 +66,9 @@ export function useBulkDeleteOrdersMutation(sourceStage: OrderStage) {
 			);
 
 			queryClient.invalidateQueries({ queryKey: DASHBOARD_STATS_QUERY_KEY });
+			queryClient.invalidateQueries({
+				queryKey: NOTIFICATION_CANDIDATES_QUERY_KEY,
+			});
 		},
 	});
 }

--- a/src/hooks/queries/useBulkUpdateOrderStageMutation.ts
+++ b/src/hooks/queries/useBulkUpdateOrderStageMutation.ts
@@ -12,6 +12,7 @@ import {
 import {
 	DASHBOARD_STATS_QUERY_KEY,
 	getOrdersQueryKey,
+	NOTIFICATION_CANDIDATES_QUERY_KEY,
 } from "@/lib/queryClient";
 import { orderService } from "@/services/orderService";
 import type { PendingRow } from "@/types";
@@ -114,6 +115,9 @@ export function useBulkUpdateOrderStageMutation(sourceStage: OrderStage) {
 			);
 
 			queryClient.invalidateQueries({ queryKey: DASHBOARD_STATS_QUERY_KEY });
+			queryClient.invalidateQueries({
+				queryKey: NOTIFICATION_CANDIDATES_QUERY_KEY,
+			});
 		},
 	});
 }

--- a/src/hooks/queries/useNotificationCandidatesQuery.ts
+++ b/src/hooks/queries/useNotificationCandidatesQuery.ts
@@ -1,0 +1,60 @@
+import {
+	type UseQueryResult,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { useEffect } from "react";
+import { NOTIFICATION_CANDIDATES_QUERY_KEY } from "@/lib/queryClient";
+import { fetchDueNotificationCandidates } from "@/services/notifications/notificationCandidatesService";
+import { useAppStore } from "@/store/useStore";
+import type { PendingRow } from "@/types";
+
+// Matches the Header's existing notification poll cadence (AC #5: polling
+// interval unchanged from the user's perspective).
+const NOTIFICATION_CANDIDATES_REFETCH_MS = 10_000;
+
+/**
+ * Keeps the server-filtered notification-candidate cache fresh and nudges
+ * `checkNotifications` to recompute whenever that cache changes. Time-driven
+ * transitions (e.g. a booking follow-up becoming due purely by the clock,
+ * with no underlying data change) are still covered by the Header's own
+ * polling interval, not by this hook.
+ */
+export function useNotificationCandidatesQuery(): UseQueryResult<
+	PendingRow[],
+	Error
+> {
+	const queryClient = useQueryClient();
+	const checkNotifications = useAppStore((s) => s.checkNotifications);
+
+	const query = useQuery<PendingRow[]>({
+		queryKey: NOTIFICATION_CANDIDATES_QUERY_KEY,
+		queryFn: fetchDueNotificationCandidates,
+		refetchInterval: NOTIFICATION_CANDIDATES_REFETCH_MS,
+		refetchOnWindowFocus: true,
+	});
+
+	// Recompute whenever the candidate set actually changes (structural
+	// sharing means an unchanged payload keeps the same reference).
+	useEffect(() => {
+		if (query.data !== undefined) {
+			checkNotifications();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [query.data, checkNotifications]);
+
+	// Preserve the existing post-mutation nudge (e.g. right after setting a
+	// reminder) by invalidating the candidate cache on the same window event.
+	useEffect(() => {
+		const handleManualCheck = () => {
+			void queryClient.invalidateQueries({
+				queryKey: NOTIFICATION_CANDIDATES_QUERY_KEY,
+			});
+		};
+		window.addEventListener("check-notifications", handleManualCheck);
+		return () =>
+			window.removeEventListener("check-notifications", handleManualCheck);
+	}, [queryClient]);
+
+	return query;
+}

--- a/src/hooks/queries/useSaveOrderMutation.ts
+++ b/src/hooks/queries/useSaveOrderMutation.ts
@@ -9,6 +9,7 @@ import {
 import {
 	DASHBOARD_STATS_QUERY_KEY,
 	getOrdersQueryKey,
+	NOTIFICATION_CANDIDATES_QUERY_KEY,
 } from "@/lib/queryClient";
 import { orderService } from "@/services/orderService";
 import type { PendingRow } from "@/types";
@@ -113,6 +114,9 @@ export function useSaveOrderMutation() {
 			}
 
 			queryClient.invalidateQueries({ queryKey: DASHBOARD_STATS_QUERY_KEY });
+			queryClient.invalidateQueries({
+				queryKey: NOTIFICATION_CANDIDATES_QUERY_KEY,
+			});
 		},
 		onSuccess: (data, variables) => {
 			let mappedRow: PendingRow;

--- a/src/hooks/useOrdersRealtimeSync.ts
+++ b/src/hooks/useOrdersRealtimeSync.ts
@@ -15,6 +15,11 @@ export function useOrdersRealtimeSync() {
 	const isDraftActive = useAppStore((s) => s.draftSession.isActive);
 	const pendingUpdate = useRef(false);
 
+	// Read draft-active state via a ref so the channel effect stays stable
+	// across draft toggles instead of tearing down and recreating the socket.
+	const isDraftActiveRef = useRef(isDraftActive);
+	isDraftActiveRef.current = isDraftActive;
+
 	// Flush any INSERT that was deferred while a draft was active.
 	// Runs whenever isDraftActive changes from true → false.
 	useEffect(() => {
@@ -42,7 +47,7 @@ export function useOrdersRealtimeSync() {
 					filter: "stage=eq.orders",
 				},
 				() => {
-					if (isDraftActive) {
+					if (isDraftActiveRef.current) {
 						pendingUpdate.current = true;
 						toast.info(
 							"New mobile orders available — refresh after saving your draft.",
@@ -66,5 +71,5 @@ export function useOrdersRealtimeSync() {
 		return () => {
 			void supabase.removeChannel(channel);
 		};
-	}, [queryClient, isDraftActive]);
+	}, [queryClient]);
 }

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -6,6 +6,11 @@ export const getOrdersQueryKey = (stage: OrderStage) =>
 
 export const DASHBOARD_STATS_QUERY_KEY = ["dashboard-stats"] as const;
 
+export const NOTIFICATION_CANDIDATES_QUERY_KEY = [
+	"notifications",
+	"candidates",
+] as const;
+
 /**
  * Creates a fresh, isolated `QueryClient`.
  *

--- a/src/services/notifications/notificationCandidatesRepository.ts
+++ b/src/services/notifications/notificationCandidatesRepository.ts
@@ -1,0 +1,167 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+import { createServiceClient } from "@/lib/supabase-admin";
+import { handleSupabaseError } from "../orderServiceErrors";
+
+// Same unfiltered embed used by the stage-fetch path (orderRepositorySelects.ts).
+// CRITICAL: this must stay unfiltered. Filtering the embedded order_reminders
+// array (e.g. via `order_reminders!inner(...)` with column filters applied to
+// the embed itself) would change which reminder `mapSupabaseOrder` picks
+// ("first uncompleted" in array order), producing a different managedKey and
+// silently resurrecting notifications the user already dismissed.
+const CANDIDATE_SELECT = `
+	id,
+	stage,
+	order_number,
+	customer_name,
+	customer_email,
+	customer_phone,
+	vin,
+	company,
+	status,
+	metadata,
+	created_at,
+	updated_at,
+	order_reminders (*)
+`;
+
+function isoDateOnly(d: Date): string {
+	return d.toISOString().slice(0, 10);
+}
+
+function throwIfError(error: PostgrestError | null): void {
+	if (error) handleSupabaseError(error);
+}
+
+function dedupeById(
+	groups: Record<string, unknown>[][],
+): Record<string, unknown>[] {
+	const seen = new Set<string>();
+	const result: Record<string, unknown>[] = [];
+	for (const group of groups) {
+		for (const row of group) {
+			const id = row.id as string;
+			if (seen.has(id)) continue;
+			seen.add(id);
+			result.push(row);
+		}
+	}
+	return result;
+}
+
+/**
+ * Fetches a small, server-filtered superset of order rows that MIGHT have a
+ * currently-due reminder, warranty expiration, booking follow-up, or CNTR-RDG
+ * warning. Every filter bound below is intentionally looser than the
+ * matching client-side threshold in `notificationSlice.checkNotifications` —
+ * the client re-checks each row exactly and is the sole source of truth for
+ * "is this actually due". The server's only job is to shrink an
+ * unbounded table scan down to a few dozen candidate rows.
+ */
+export function createNotificationCandidatesRepository(
+	db: ReturnType<typeof createServiceClient> = createServiceClient(),
+) {
+	return {
+		async getDueNotificationCandidates(): Promise<Record<string, unknown>[]> {
+			const now = new Date();
+
+			// --- Reminders: any non-archived order with an uncompleted reminder
+			// due within the next minute (the +1min covers the client mapper's
+			// minute-truncated local time comparison). Two-step so the candidacy
+			// filter never shapes the embed returned for mapping (see comment above
+			// CANDIDATE_SELECT).
+			const reminderCutoff = new Date(now.getTime() + 60_000).toISOString();
+			const reminderIdsQuery = await db
+				.from("orders")
+				.select("id, order_reminders!inner(id)")
+				.neq("stage", "archive")
+				.not("order_reminders.is_completed", "eq", true)
+				.lte("order_reminders.remind_at", reminderCutoff)
+				.order("created_at", { ascending: true })
+				.order("id", { ascending: true });
+			throwIfError(reminderIdsQuery.error);
+			const reminderIds = (reminderIdsQuery.data ?? []).map(
+				(row) => (row as { id: string }).id,
+			);
+
+			let reminderRows: Record<string, unknown>[] = [];
+			if (reminderIds.length > 0) {
+				const remindersQuery = await db
+					.from("orders")
+					.select(CANDIDATE_SELECT)
+					.in("id", reminderIds)
+					.order("created_at", { ascending: true })
+					.order("id", { ascending: true });
+				throwIfError(remindersQuery.error);
+				reminderRows = (remindersQuery.data ?? []) as unknown as Record<
+					string,
+					unknown
+				>[];
+			}
+
+			// --- Warranty: endWarranty within [-2d, +37d] of now — a superset of
+			// the client's [0, 35] day window, padded for clock/date-parsing slack.
+			const warrantyMin = isoDateOnly(
+				new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
+			);
+			const warrantyMax = isoDateOnly(
+				new Date(now.getTime() + 37 * 24 * 60 * 60 * 1000),
+			);
+			const warrantyQuery = await db
+				.from("orders")
+				.select(CANDIDATE_SELECT)
+				.neq("stage", "archive")
+				.filter("metadata->>endWarranty", "neq", "")
+				.filter("metadata->>endWarranty", "gte", warrantyMin)
+				.filter("metadata->>endWarranty", "lte", warrantyMax)
+				.order("created_at", { ascending: true })
+				.order("id", { ascending: true });
+			throwIfError(warrantyQuery.error);
+			const warrantyRows = (warrantyQuery.data ?? []) as unknown as Record<
+				string,
+				unknown
+			>[];
+
+			// --- Booking follow-up: bookingDate <= tomorrow (1-day slack covers
+			// the client's "day after at 10:00 local" rule across timezones).
+			const bookingMax = isoDateOnly(
+				new Date(now.getTime() + 24 * 60 * 60 * 1000),
+			);
+			const bookingQuery = await db
+				.from("orders")
+				.select(CANDIDATE_SELECT)
+				.eq("stage", "booking")
+				.filter("metadata->>bookingDate", "neq", "")
+				.filter("metadata->>bookingDate", "lte", bookingMax)
+				.order("created_at", { ascending: true })
+				.order("id", { ascending: true });
+			throwIfError(bookingQuery.error);
+			const bookingRows = (bookingQuery.data ?? []) as unknown as Record<
+				string,
+				unknown
+			>[];
+
+			// --- CNTR-RDG warning: warranty-repair rows on Main Sheet created at
+			// least 9 days ago — a superset of the tighter HIGH_RISK_DAYS=10
+			// threshold (minus a day of floor/timezone slack). Numeric cntrRdg
+			// thresholds (70k/85k) are applied client-side.
+			const cntrCutoff = new Date(
+				now.getTime() - 9 * 24 * 60 * 60 * 1000,
+			).toISOString();
+			const cntrQuery = await db
+				.from("orders")
+				.select(CANDIDATE_SELECT)
+				.eq("stage", "main")
+				.filter("metadata->>repairSystem", "eq", "ضمان")
+				.lte("created_at", cntrCutoff)
+				.order("created_at", { ascending: true })
+				.order("id", { ascending: true });
+			throwIfError(cntrQuery.error);
+			const cntrRows = (cntrQuery.data ?? []) as unknown as Record<
+				string,
+				unknown
+			>[];
+
+			return dedupeById([reminderRows, warrantyRows, bookingRows, cntrRows]);
+		},
+	};
+}

--- a/src/services/notifications/notificationCandidatesRepository.ts
+++ b/src/services/notifications/notificationCandidatesRepository.ts
@@ -60,43 +60,44 @@ function dedupeById(
 export function createNotificationCandidatesRepository(
 	db: ReturnType<typeof createServiceClient> = createServiceClient(),
 ) {
+	// --- Reminders: any non-archived order with an uncompleted reminder due
+	// within the next minute (the +1min covers the client mapper's
+	// minute-truncated local time comparison). Two-step so the candidacy filter
+	// never shapes the embed returned for mapping (see comment above
+	// CANDIDATE_SELECT): the first query only finds which orders qualify, the
+	// second re-fetches them with the FULL unfiltered order_reminders embed.
+	async function fetchReminderRows(
+		now: Date,
+	): Promise<Record<string, unknown>[]> {
+		const reminderCutoff = new Date(now.getTime() + 60_000).toISOString();
+		const reminderIdsQuery = await db
+			.from("orders")
+			.select("id, order_reminders!inner(id)")
+			.neq("stage", "archive")
+			.not("order_reminders.is_completed", "eq", true)
+			.lte("order_reminders.remind_at", reminderCutoff)
+			.order("created_at", { ascending: true })
+			.order("id", { ascending: true });
+		throwIfError(reminderIdsQuery.error);
+		const reminderIds = (reminderIdsQuery.data ?? []).map(
+			(row) => (row as { id: string }).id,
+		);
+
+		if (reminderIds.length === 0) return [];
+
+		const remindersQuery = await db
+			.from("orders")
+			.select(CANDIDATE_SELECT)
+			.in("id", reminderIds)
+			.order("created_at", { ascending: true })
+			.order("id", { ascending: true });
+		throwIfError(remindersQuery.error);
+		return (remindersQuery.data ?? []) as unknown as Record<string, unknown>[];
+	}
+
 	return {
 		async getDueNotificationCandidates(): Promise<Record<string, unknown>[]> {
 			const now = new Date();
-
-			// --- Reminders: any non-archived order with an uncompleted reminder
-			// due within the next minute (the +1min covers the client mapper's
-			// minute-truncated local time comparison). Two-step so the candidacy
-			// filter never shapes the embed returned for mapping (see comment above
-			// CANDIDATE_SELECT).
-			const reminderCutoff = new Date(now.getTime() + 60_000).toISOString();
-			const reminderIdsQuery = await db
-				.from("orders")
-				.select("id, order_reminders!inner(id)")
-				.neq("stage", "archive")
-				.not("order_reminders.is_completed", "eq", true)
-				.lte("order_reminders.remind_at", reminderCutoff)
-				.order("created_at", { ascending: true })
-				.order("id", { ascending: true });
-			throwIfError(reminderIdsQuery.error);
-			const reminderIds = (reminderIdsQuery.data ?? []).map(
-				(row) => (row as { id: string }).id,
-			);
-
-			let reminderRows: Record<string, unknown>[] = [];
-			if (reminderIds.length > 0) {
-				const remindersQuery = await db
-					.from("orders")
-					.select(CANDIDATE_SELECT)
-					.in("id", reminderIds)
-					.order("created_at", { ascending: true })
-					.order("id", { ascending: true });
-				throwIfError(remindersQuery.error);
-				reminderRows = (remindersQuery.data ?? []) as unknown as Record<
-					string,
-					unknown
-				>[];
-			}
 
 			// --- Warranty: endWarranty within [-2d, +37d] of now — a superset of
 			// the client's [0, 35] day window, padded for clock/date-parsing slack.
@@ -106,39 +107,12 @@ export function createNotificationCandidatesRepository(
 			const warrantyMax = isoDateOnly(
 				new Date(now.getTime() + 37 * 24 * 60 * 60 * 1000),
 			);
-			const warrantyQuery = await db
-				.from("orders")
-				.select(CANDIDATE_SELECT)
-				.neq("stage", "archive")
-				.filter("metadata->>endWarranty", "neq", "")
-				.filter("metadata->>endWarranty", "gte", warrantyMin)
-				.filter("metadata->>endWarranty", "lte", warrantyMax)
-				.order("created_at", { ascending: true })
-				.order("id", { ascending: true });
-			throwIfError(warrantyQuery.error);
-			const warrantyRows = (warrantyQuery.data ?? []) as unknown as Record<
-				string,
-				unknown
-			>[];
 
 			// --- Booking follow-up: bookingDate <= tomorrow (1-day slack covers
 			// the client's "day after at 10:00 local" rule across timezones).
 			const bookingMax = isoDateOnly(
 				new Date(now.getTime() + 24 * 60 * 60 * 1000),
 			);
-			const bookingQuery = await db
-				.from("orders")
-				.select(CANDIDATE_SELECT)
-				.eq("stage", "booking")
-				.filter("metadata->>bookingDate", "neq", "")
-				.filter("metadata->>bookingDate", "lte", bookingMax)
-				.order("created_at", { ascending: true })
-				.order("id", { ascending: true });
-			throwIfError(bookingQuery.error);
-			const bookingRows = (bookingQuery.data ?? []) as unknown as Record<
-				string,
-				unknown
-			>[];
 
 			// --- CNTR-RDG warning: warranty-repair rows on Main Sheet created at
 			// least 9 days ago — a superset of the tighter HIGH_RISK_DAYS=10
@@ -147,16 +121,53 @@ export function createNotificationCandidatesRepository(
 			const cntrCutoff = new Date(
 				now.getTime() - 9 * 24 * 60 * 60 * 1000,
 			).toISOString();
-			const cntrQuery = await db
-				.from("orders")
-				.select(CANDIDATE_SELECT)
-				.eq("stage", "main")
-				.filter("metadata->>repairSystem", "eq", "ضمان")
-				.lte("created_at", cntrCutoff)
-				.order("created_at", { ascending: true })
-				.order("id", { ascending: true });
-			throwIfError(cntrQuery.error);
-			const cntrRows = (cntrQuery.data ?? []) as unknown as Record<
+
+			// The reminder phase and the three single-stage queries are mutually
+			// independent, so run them concurrently (only the reminder id→embed
+			// step is internally sequential).
+			const [reminderRows, warrantyResult, bookingResult, cntrResult] =
+				await Promise.all([
+					fetchReminderRows(now),
+					db
+						.from("orders")
+						.select(CANDIDATE_SELECT)
+						.neq("stage", "archive")
+						.filter("metadata->>endWarranty", "neq", "")
+						.filter("metadata->>endWarranty", "gte", warrantyMin)
+						.filter("metadata->>endWarranty", "lte", warrantyMax)
+						.order("created_at", { ascending: true })
+						.order("id", { ascending: true }),
+					db
+						.from("orders")
+						.select(CANDIDATE_SELECT)
+						.eq("stage", "booking")
+						.filter("metadata->>bookingDate", "neq", "")
+						.filter("metadata->>bookingDate", "lte", bookingMax)
+						.order("created_at", { ascending: true })
+						.order("id", { ascending: true }),
+					db
+						.from("orders")
+						.select(CANDIDATE_SELECT)
+						.eq("stage", "main")
+						.filter("metadata->>repairSystem", "eq", "ضمان")
+						.lte("created_at", cntrCutoff)
+						.order("created_at", { ascending: true })
+						.order("id", { ascending: true }),
+				]);
+
+			throwIfError(warrantyResult.error);
+			throwIfError(bookingResult.error);
+			throwIfError(cntrResult.error);
+
+			const warrantyRows = (warrantyResult.data ?? []) as unknown as Record<
+				string,
+				unknown
+			>[];
+			const bookingRows = (bookingResult.data ?? []) as unknown as Record<
+				string,
+				unknown
+			>[];
+			const cntrRows = (cntrResult.data ?? []) as unknown as Record<
 				string,
 				unknown
 			>[];

--- a/src/services/notifications/notificationCandidatesService.ts
+++ b/src/services/notifications/notificationCandidatesService.ts
@@ -1,0 +1,29 @@
+import { mapSupabaseOrder } from "@/services/orderMapper";
+import type { PendingRow } from "@/types";
+
+/**
+ * Fetches the server-filtered candidate rows and maps them through the same
+ * `mapSupabaseOrder` used by the stage-fetch path, so reminder derivation
+ * (client-local date/time) and managedKey construction stay identical.
+ *
+ * Mirrors `fetchMappedOrders` (orderQueryRepository.ts): if any row fails
+ * mapping, the whole fetch throws rather than silently dropping the row.
+ * React Query then keeps the previous good candidate set instead of the
+ * notification engine seeing a partial set and wrongly pruning dismissed
+ * keys for rows that merely failed to map this cycle.
+ */
+export async function fetchDueNotificationCandidates(): Promise<PendingRow[]> {
+	const response = await fetch("/api/notifications");
+	if (!response.ok) {
+		const errorData = (await response.json().catch(() => ({}))) as {
+			error?: string;
+		};
+		throw new Error(errorData.error ?? `Server error: ${response.status}`);
+	}
+
+	const { candidates } = (await response.json()) as {
+		candidates: Record<string, unknown>[];
+	};
+
+	return candidates.map((row) => mapSupabaseOrder(row));
+}

--- a/src/store/ordersQueryAdapter.ts
+++ b/src/store/ordersQueryAdapter.ts
@@ -1,7 +1,10 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { OrderStage } from "@/domain/order/orderStage";
 import { logger } from "@/lib/logger";
-import { getOrdersQueryKey } from "@/lib/queryClient";
+import {
+	getOrdersQueryKey,
+	NOTIFICATION_CANDIDATES_QUERY_KEY,
+} from "@/lib/queryClient";
 import type { PendingRow } from "@/types";
 
 /**
@@ -18,6 +21,8 @@ export interface OrdersQueryAdapter {
 	getStageRows: (stage: OrderStage) => PendingRow[] | undefined;
 	isStageLoaded: (stage: OrderStage) => boolean;
 	invalidateStage: (stage: OrderStage) => void;
+	getDueNotificationCandidates: () => PendingRow[] | undefined;
+	isDueCandidatesLoaded: () => boolean;
 }
 
 /**
@@ -30,6 +35,8 @@ const noopAdapter: OrdersQueryAdapter = {
 	getStageRows: () => undefined,
 	isStageLoaded: () => false,
 	invalidateStage: () => {},
+	getDueNotificationCandidates: () => undefined,
+	isDueCandidatesLoaded: () => false,
 };
 
 let registered: OrdersQueryAdapter = noopAdapter;
@@ -81,5 +88,11 @@ export function createReactQueryAdapter(
 		invalidateStage: (stage) => {
 			queryClient.invalidateQueries({ queryKey: getOrdersQueryKey(stage) });
 		},
+		getDueNotificationCandidates: () =>
+			queryClient.getQueryData<PendingRow[]>(NOTIFICATION_CANDIDATES_QUERY_KEY),
+		isDueCandidatesLoaded: () =>
+			queryClient.getQueryData<PendingRow[]>(
+				NOTIFICATION_CANDIDATES_QUERY_KEY,
+			) !== undefined,
 	};
 }

--- a/src/store/slices/notificationSlice.ts
+++ b/src/store/slices/notificationSlice.ts
@@ -1,12 +1,19 @@
 import type { StateCreator } from "zustand";
 import { generateId } from "@/lib/utils";
-import type { AppNotification } from "@/types";
+import type { AppNotification, PendingRow } from "@/types";
 import { getOrdersQueryAdapter } from "../ordersQueryAdapter";
 import type {
 	CombinedStore,
 	NotificationActions,
 	NotificationState,
 } from "../types";
+
+const STAGE_TAB_INFO: Record<string, { name: string; path: string }> = {
+	main: { name: "Main Sheet", path: "/main-sheet" },
+	orders: { name: "Orders", path: "/orders" },
+	booking: { name: "Booking", path: "/booking" },
+	call: { name: "Call List", path: "/call-list" },
+};
 
 export const createNotificationSlice: StateCreator<
 	CombinedStore,
@@ -92,88 +99,61 @@ export const createNotificationSlice: StateCreator<
 		>[] = [];
 
 		const adapter = getOrdersQueryAdapter();
-		const sources = [
-			{
-				data: adapter.getStageRows("main") ?? [],
-				isLoaded: adapter.isStageLoaded("main"),
-				name: "Main Sheet",
-				path: "/main-sheet",
-			},
-			{
-				data: adapter.getStageRows("orders") ?? [],
-				isLoaded: adapter.isStageLoaded("orders"),
-				name: "Orders",
-				path: "/orders",
-			},
-			{
-				data: adapter.getStageRows("booking") ?? [],
-				isLoaded: adapter.isStageLoaded("booking"),
-				name: "Booking",
-				path: "/booking",
-			},
-			{
-				data: adapter.getStageRows("call") ?? [],
-				isLoaded: adapter.isStageLoaded("call"),
-				name: "Call List",
-				path: "/call-list",
-			},
-		];
-
-		const allCachesLoaded = sources.every((s) => s.isLoaded);
+		const rows: PendingRow[] = adapter.getDueNotificationCandidates() ?? [];
+		const allCachesLoaded = adapter.isDueCandidatesLoaded();
 		const activeManagedKeys = new Set<string>();
 
-		for (const source of sources) {
-			for (const row of source.data) {
-				// Check Reminders
-				if (row.reminder) {
-					const reminderTimeStr = row.reminder.time || "00:00";
-					const reminderDateStr = `${row.reminder.date}T${reminderTimeStr}`;
-					const reminderDate = new Date(reminderDateStr);
+		for (const row of rows) {
+			const tabInfo = row.stage ? STAGE_TAB_INFO[row.stage] : undefined;
+			const tabName = tabInfo?.name ?? "Orders";
+			const path = tabInfo?.path ?? "/orders";
 
-					if (now >= reminderDate) {
-						const managedKey = `reminder:${row.id}:${row.reminder.date}:${reminderTimeStr}:${row.reminder.subject}`;
+			// Check Reminders
+			if (row.reminder) {
+				const reminderTimeStr = row.reminder.time || "00:00";
+				const reminderDateStr = `${row.reminder.date}T${reminderTimeStr}`;
+				const reminderDate = new Date(reminderDateStr);
+
+				if (now >= reminderDate) {
+					const managedKey = `reminder:${row.id}:${row.reminder.date}:${reminderTimeStr}:${row.reminder.subject}`;
+					activeManagedKeys.add(managedKey);
+
+					currentlyDueReminders.push({
+						type: "reminder",
+						title: "Reminder Due",
+						description: `Due: ${row.reminder.date} ${row.reminder.time || ""} - ${row.customerName}: ${row.reminder.subject}`,
+						referenceId: row.id,
+						vin: row.vin,
+						trackingId: row.trackingId,
+						tabName,
+						path,
+						managedKey,
+					});
+				}
+			}
+
+			// Check Warranty Expiration
+			if (row.endWarranty) {
+				const endDate = new Date(row.endWarranty);
+				if (!Number.isNaN(endDate.getTime())) {
+					const diffTime = endDate.getTime() - now.getTime();
+					const daysRemaining = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+					if (daysRemaining >= 0 && daysRemaining <= WARRANTY_THRESHOLD_DAYS) {
+						const managedKey = `warranty:${row.id}:${row.endWarranty}`;
 						activeManagedKeys.add(managedKey);
 
-						currentlyDueReminders.push({
-							type: "reminder",
-							title: "Reminder Due",
-							description: `Due: ${row.reminder.date} ${row.reminder.time || ""} - ${row.customerName}: ${row.reminder.subject}`,
+						currentlyDueWarranties.push({
+							type: "warranty",
+							title: "Warranty Expiring",
+							description: `Warranty expires in ${daysRemaining} days (${row.endWarranty})`,
 							referenceId: row.id,
 							vin: row.vin,
 							trackingId: row.trackingId,
-							tabName: source.name,
-							path: source.path,
+							tabName,
+							path,
 							managedKey,
 						});
-					}
-				}
-
-				// Check Warranty Expiration
-				if (row.endWarranty) {
-					const endDate = new Date(row.endWarranty);
-					if (!Number.isNaN(endDate.getTime())) {
-						const diffTime = endDate.getTime() - now.getTime();
-						const daysRemaining = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-						if (
-							daysRemaining >= 0 &&
-							daysRemaining <= WARRANTY_THRESHOLD_DAYS
-						) {
-							const managedKey = `warranty:${row.id}:${row.endWarranty}`;
-							activeManagedKeys.add(managedKey);
-
-							currentlyDueWarranties.push({
-								type: "warranty",
-								title: "Warranty Expiring",
-								description: `Warranty expires in ${daysRemaining} days (${row.endWarranty})`,
-								referenceId: row.id,
-								vin: row.vin,
-								trackingId: row.trackingId,
-								tabName: source.name,
-								path: source.path,
-								managedKey,
-							});
-						}
 					}
 				}
 			}
@@ -184,10 +164,10 @@ export const createNotificationSlice: StateCreator<
 			"id" | "timestamp" | "isRead"
 		>[] = [];
 
-		const bookingSource = sources.find((s) => s.path === "/booking");
-		if (bookingSource) {
+		const bookingRows = rows.filter((row) => row.stage === "booking");
+		{
 			const seenKeys = new Set<string>();
-			for (const row of bookingSource.data) {
+			for (const row of bookingRows) {
 				if (!row.bookingDate) continue;
 				const key = `${row.vin}::${row.bookingDate}`;
 				if (seenKeys.has(key)) continue;
@@ -229,51 +209,46 @@ export const createNotificationSlice: StateCreator<
 			"id" | "timestamp" | "isRead"
 		>[] = [];
 
-		const mainSheetSource = sources.find((s) => s.path === "/main-sheet");
-		if (mainSheetSource) {
-			for (const row of mainSheetSource.data) {
-				if (row.repairSystem !== WARRANTY_REPAIR_SYSTEM) continue;
-				if (!row.createdAt) continue;
+		const mainSheetRows = rows.filter((row) => row.stage === "main");
+		for (const row of mainSheetRows) {
+			if (row.repairSystem !== WARRANTY_REPAIR_SYSTEM) continue;
+			if (!row.createdAt) continue;
 
-				const daysSinceCreation = Math.floor(
-					(now.getTime() - new Date(row.createdAt).getTime()) / MS_PER_DAY,
-				);
-				if (Number.isNaN(daysSinceCreation)) continue;
+			const daysSinceCreation = Math.floor(
+				(now.getTime() - new Date(row.createdAt).getTime()) / MS_PER_DAY,
+			);
+			if (Number.isNaN(daysSinceCreation)) continue;
 
-				let level: "high" | "early" | null = null;
-				if (
-					row.cntrRdg >= HIGH_RISK_KM &&
-					daysSinceCreation >= HIGH_RISK_DAYS
-				) {
-					level = "high";
-				} else if (
-					row.cntrRdg >= EARLY_WARNING_KM &&
-					daysSinceCreation >= EARLY_WARNING_DAYS
-				) {
-					level = "early";
-				}
-
-				if (!level) continue;
-
-				const managedKey = `cntr_rdg_warning:${row.id}:${level}`;
-				activeManagedKeys.add(managedKey);
-
-				currentlyDueCntrWarnings.push({
-					type: "cntr_rdg_warning",
-					cntrRdgLevel: level,
-					title:
-						level === "high"
-							? "High Risk: CNTR RDG Warning"
-							: "Early Warning: CNTR RDG",
-					description: `${row.customerName} — ${row.cntrRdg.toLocaleString()} KM (VIN: ${row.vin})`,
-					referenceId: row.id,
-					vin: row.vin,
-					trackingId: row.trackingId,
-					tabName: "Main Sheet",
-					path: "/main-sheet",
-					managedKey,
-				});
+			let level: "high" | "early" | null = null;
+			if (row.cntrRdg >= HIGH_RISK_KM && daysSinceCreation >= HIGH_RISK_DAYS) {
+				level = "high";
+			} else if (
+				row.cntrRdg >= EARLY_WARNING_KM &&
+				daysSinceCreation >= EARLY_WARNING_DAYS
+			) {
+				level = "early";
 			}
+
+			if (!level) continue;
+
+			const managedKey = `cntr_rdg_warning:${row.id}:${level}`;
+			activeManagedKeys.add(managedKey);
+
+			currentlyDueCntrWarnings.push({
+				type: "cntr_rdg_warning",
+				cntrRdgLevel: level,
+				title:
+					level === "high"
+						? "High Risk: CNTR RDG Warning"
+						: "Early Warning: CNTR RDG",
+				description: `${row.customerName} — ${row.cntrRdg.toLocaleString()} KM (VIN: ${row.vin})`,
+				referenceId: row.id,
+				vin: row.vin,
+				trackingId: row.trackingId,
+				tabName: "Main Sheet",
+				path: "/main-sheet",
+				managedKey,
+			});
 		}
 
 		// 2. Synchronize store state

--- a/src/test/QueryProvider.test.tsx
+++ b/src/test/QueryProvider.test.tsx
@@ -3,7 +3,10 @@ import { render } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import QueryProvider from "@/components/providers/QueryProvider";
-import { getOrdersQueryKey } from "@/lib/queryClient";
+import {
+	getOrdersQueryKey,
+	NOTIFICATION_CANDIDATES_QUERY_KEY,
+} from "@/lib/queryClient";
 import { getOrdersQueryAdapter } from "@/store/ordersQueryAdapter";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
@@ -102,10 +105,11 @@ describe("QueryProvider", () => {
 		const { client } = renderProviderAndCaptureClient();
 
 		// Seed the live client the provider is bound to (not a stale singleton).
-		client.setQueryData(getOrdersQueryKey("orders"), [makeReminderRow("1")]);
-		client.setQueryData(getOrdersQueryKey("main"), []);
-		client.setQueryData(getOrdersQueryKey("booking"), []);
-		client.setQueryData(getOrdersQueryKey("call"), []);
+		// checkNotifications reads the server-fetched candidate cache, not the
+		// per-stage caches, so that's what needs seeding here.
+		client.setQueryData(NOTIFICATION_CANDIDATES_QUERY_KEY, [
+			makeReminderRow("1"),
+		]);
 
 		act(() => {
 			useAppStore.getState().checkNotifications();

--- a/src/test/api/notifications.route.test.ts
+++ b/src/test/api/notifications.route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/server", () => ({
+	NextResponse: {
+		json: (body: unknown, init?: { status?: number }) => ({
+			body,
+			status: init?.status ?? 200,
+			json: async () => body,
+		}),
+	},
+}));
+
+vi.mock("@/lib/auth", () => ({
+	auth: {
+		api: {
+			getSession: vi.fn(),
+		},
+	},
+}));
+
+const mockGetDueNotificationCandidates = vi.fn();
+vi.mock("@/services/notifications/notificationCandidatesRepository", () => ({
+	createNotificationCandidatesRepository: () => ({
+		getDueNotificationCandidates: mockGetDueNotificationCandidates,
+	}),
+}));
+
+function makeRequest() {
+	return {
+		headers: new Headers(),
+	} as unknown as import("next/server").NextRequest;
+}
+
+function makeSession() {
+	return { user: { id: "user-1" } } as unknown as Awaited<
+		ReturnType<typeof import("@/lib/auth").auth.api.getSession>
+	>;
+}
+
+describe("GET /api/notifications", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
+
+	it("returns 401 when there is no session", async () => {
+		const { auth } = await import("@/lib/auth");
+		vi.mocked(auth.api.getSession).mockResolvedValue(null);
+
+		const { GET } = await import("@/app/api/notifications/route");
+		const res = await GET(makeRequest());
+
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 200 with candidates when authenticated", async () => {
+		const { auth } = await import("@/lib/auth");
+		vi.mocked(auth.api.getSession).mockResolvedValue(makeSession());
+		mockGetDueNotificationCandidates.mockResolvedValue([{ id: "row-1" }]);
+
+		const { GET } = await import("@/app/api/notifications/route");
+		const res = await GET(makeRequest());
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.candidates).toEqual([{ id: "row-1" }]);
+	});
+
+	it("returns 500 when the repository throws", async () => {
+		const { auth } = await import("@/lib/auth");
+		vi.mocked(auth.api.getSession).mockResolvedValue(makeSession());
+		mockGetDueNotificationCandidates.mockRejectedValue(new Error("db down"));
+
+		const { GET } = await import("@/app/api/notifications/route");
+		const res = await GET(makeRequest());
+
+		expect(res.status).toBe(500);
+	});
+});

--- a/src/test/notificationSlice.test.ts
+++ b/src/test/notificationSlice.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
-import { getOrdersQueryKey } from "@/lib/queryClient";
+import { NOTIFICATION_CANDIDATES_QUERY_KEY } from "@/lib/queryClient";
+import type { OrderStage } from "../domain/order/orderStage";
 import { createNotificationSlice } from "../store/slices/notificationSlice";
 import type { CombinedStore } from "../store/types";
 import type { PendingRow } from "../types";
@@ -14,7 +15,11 @@ vi.mock("@/services/orderService", () => ({
 }));
 
 // Mock row helper
-const createMockRow = (id: string, endWarranty?: string): PendingRow => ({
+const createMockRow = (
+	id: string,
+	endWarranty?: string,
+	stage: OrderStage = "orders",
+): PendingRow => ({
 	id,
 	baseId: `B${id}`,
 	trackingId: `T${id}`,
@@ -36,6 +41,7 @@ const createMockRow = (id: string, endWarranty?: string): PendingRow => ({
 	startWarranty: "",
 	endWarranty: endWarranty || "",
 	remainTime: "",
+	stage,
 });
 
 const createCntrWarrantyRow = (
@@ -43,7 +49,7 @@ const createCntrWarrantyRow = (
 	cntrRdg: number,
 	createdAt: string,
 ): PendingRow => ({
-	...createMockRow(id),
+	...createMockRow(id, undefined, "main"),
 	repairSystem: "ضمان",
 	cntrRdg,
 	createdAt,
@@ -51,10 +57,7 @@ const createCntrWarrantyRow = (
 
 describe("notificationSlice", () => {
 	const createTestStore = (rows: PendingRow[]) => {
-		queryClient.setQueryData(getOrdersQueryKey("orders"), rows);
-		queryClient.setQueryData(getOrdersQueryKey("main"), []);
-		queryClient.setQueryData(getOrdersQueryKey("booking"), []);
-		queryClient.setQueryData(getOrdersQueryKey("call"), []);
+		queryClient.setQueryData(NOTIFICATION_CANDIDATES_QUERY_KEY, rows);
 
 		return create<CombinedStore>(
 			(...a) =>
@@ -68,22 +71,8 @@ describe("notificationSlice", () => {
 		);
 	};
 
-	const createMainSheetStore = (mainRows: PendingRow[]) => {
-		queryClient.setQueryData(getOrdersQueryKey("orders"), []);
-		queryClient.setQueryData(getOrdersQueryKey("main"), mainRows);
-		queryClient.setQueryData(getOrdersQueryKey("booking"), []);
-		queryClient.setQueryData(getOrdersQueryKey("call"), []);
-
-		return create<CombinedStore>(
-			(...a) =>
-				({
-					// biome-ignore lint/suspicious/noExplicitAny: Bypass middleware checks for testing
-					...createNotificationSlice(a[0], a[1], a[2] as any),
-					notifications: [],
-					// biome-ignore lint/suspicious/noExplicitAny: Test mock setup
-				}) as unknown as any,
-		);
-	};
+	const createMainSheetStore = (mainRows: PendingRow[]) =>
+		createTestStore(mainRows);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -175,6 +164,79 @@ describe("notificationSlice", () => {
 		expect(store.getState().notifications).toHaveLength(0);
 	});
 
+	describe("Server-authoritative candidate source (MAH-39)", () => {
+		it("surfaces a reminder from a stage whose page has never been opened in this session", () => {
+			const now = new Date("2026-03-01T12:00:00Z");
+			vi.setSystemTime(now);
+
+			// Simulate: no per-stage query key was ever seeded (user never visited
+			// any stage page) — only the server-fetched candidate set exists.
+			const row = createMockRow("1", undefined, "call");
+			row.reminder = {
+				date: "2026-03-01",
+				time: "10:00",
+				subject: "Follow up",
+			};
+
+			const store = createTestStore([row]);
+
+			store.getState().checkNotifications();
+
+			const notifications = store.getState().notifications;
+			expect(notifications).toHaveLength(1);
+			expect(notifications[0].type).toBe("reminder");
+			expect(notifications[0].tabName).toBe("Call List");
+			expect(notifications[0].path).toBe("/call-list");
+		});
+
+		it("preserves dismissed keys and resurfaces the item once the candidate cache is refetched after eviction", () => {
+			const now = new Date("2026-03-01T12:00:00Z");
+			vi.setSystemTime(now);
+
+			const row = createMockRow("1");
+			row.reminder = { date: "2026-03-01", time: "10:00", subject: "Call" };
+
+			const store = createTestStore([row]);
+			store.getState().checkNotifications();
+			expect(store.getState().notifications).toHaveLength(1);
+
+			store.getState().removeNotification(store.getState().notifications[0].id);
+			expect(store.getState().notifications).toHaveLength(0);
+			expect(
+				Object.keys(store.getState().dismissedManagedNotificationKeys),
+			).toHaveLength(1);
+
+			// Candidate cache is garbage-collected (simulates React Query GC).
+			queryClient.removeQueries({
+				queryKey: NOTIFICATION_CANDIDATES_QUERY_KEY,
+			});
+			store.getState().checkNotifications();
+
+			// isDueCandidatesLoaded() is now false — dismissed keys must be preserved,
+			// not pruned, exactly like the old per-stage "unloaded" guard.
+			expect(
+				Object.keys(store.getState().dismissedManagedNotificationKeys),
+			).toHaveLength(1);
+			expect(store.getState().notifications).toHaveLength(0);
+
+			// Candidate cache refetches (data reappears) — the still-due item must
+			// stay suppressed since it was dismissed and never actually became
+			// not-due.
+			queryClient.setQueryData(NOTIFICATION_CANDIDATES_QUERY_KEY, [row]);
+			store.getState().checkNotifications();
+			expect(store.getState().notifications).toHaveLength(0);
+
+			// Now simulate the reminder actually being cleared — on next fetch with
+			// all data present, the dismissed key should finally be pruned.
+			const clearedRow = { ...row, reminder: null };
+			queryClient.setQueryData(NOTIFICATION_CANDIDATES_QUERY_KEY, [clearedRow]);
+			store.getState().checkNotifications();
+			expect(
+				Object.keys(store.getState().dismissedManagedNotificationKeys),
+			).toHaveLength(0);
+		});
+	});
+
 	describe("Reminder Dismissal Logic", () => {
 		it("should not respawn a dismissed notification on next sync", () => {
 			const now = new Date("2026-03-01T12:00:00Z");
@@ -254,6 +316,7 @@ describe("notificationSlice", () => {
 
 			// Admin edits the reminder subject
 			r1.reminder.subject = "Updated";
+			queryClient.setQueryData(NOTIFICATION_CANDIDATES_QUERY_KEY, [r1]);
 
 			// Next sync should spawn a NEW notification
 			store.getState().checkNotifications();
@@ -280,7 +343,8 @@ describe("notificationSlice", () => {
 			).toHaveLength(1);
 
 			// Simulating the user fulfilled the reminder by deleting it from the row
-			r1.reminder = null;
+			const clearedRow = { ...r1, reminder: null };
+			queryClient.setQueryData(NOTIFICATION_CANDIDATES_QUERY_KEY, [clearedRow]);
 
 			// Next sync
 			store.getState().checkNotifications();
@@ -290,7 +354,7 @@ describe("notificationSlice", () => {
 			).toHaveLength(0);
 		});
 
-		it("should NOT prune dismissed keys if any cache is unloaded", () => {
+		it("should NOT prune dismissed keys if the candidate cache is unloaded", () => {
 			const now = new Date("2026-03-01T12:00:00Z");
 			vi.setSystemTime(now);
 
@@ -306,19 +370,99 @@ describe("notificationSlice", () => {
 				Object.keys(store.getState().dismissedManagedNotificationKeys),
 			).toHaveLength(1);
 
-			// 2. Simulate the user fulfilling or changing the reminder
-			r1.reminder = null;
+			// 2. Simulate the candidate cache being garbage-collected before the
+			// reminder was actually cleared (isDueCandidatesLoaded() -> false).
+			queryClient.removeQueries({
+				queryKey: NOTIFICATION_CANDIDATES_QUERY_KEY,
+			});
 
-			// 3. Simulate one cache being unloaded (e.g., user hasn't visited "main" yet)
-			queryClient.removeQueries({ queryKey: getOrdersQueryKey("main") });
-
-			// 4. Next sync - caches are partially loaded
+			// 3. Next sync - candidate set is unloaded
 			store.getState().checkNotifications();
 
-			// The dismissed keys should be PRESERVED, not pruned, since allCachesLoaded = false
+			// The dismissed keys should be PRESERVED, not pruned.
 			expect(
 				Object.keys(store.getState().dismissedManagedNotificationKeys),
 			).toHaveLength(1);
+		});
+	});
+
+	describe("Booking Follow-up", () => {
+		it("does not fire before the next-day 10:00 local follow-up time", () => {
+			const now = new Date(2026, 2, 2, 9, 59, 0); // local: 2026-03-02 09:59
+			vi.setSystemTime(now);
+
+			const row = createMockRow("1", undefined, "booking");
+			row.bookingDate = "2026-03-01";
+
+			const store = createTestStore([row]);
+			store.getState().checkNotifications();
+
+			expect(store.getState().notifications).toHaveLength(0);
+		});
+
+		it("fires at/after the next-day 10:00 local follow-up time", () => {
+			const now = new Date(2026, 2, 2, 10, 0, 0); // local: 2026-03-02 10:00
+			vi.setSystemTime(now);
+
+			const row = createMockRow("1", undefined, "booking");
+			row.bookingDate = "2026-03-01";
+
+			const store = createTestStore([row]);
+			store.getState().checkNotifications();
+
+			const notifications = store.getState().notifications;
+			expect(notifications).toHaveLength(1);
+			expect(notifications[0].type).toBe("booking_followup");
+			expect(notifications[0].managedKey).toBe(
+				`booking_followup:${row.vin}:2026-03-01`,
+			);
+		});
+
+		it("dedupes multiple rows sharing the same vin + bookingDate and keeps a stable referenceId", () => {
+			const now = new Date(2026, 2, 2, 10, 0, 0);
+			vi.setSystemTime(now);
+
+			const rowA = createMockRow("1", undefined, "booking");
+			rowA.vin = "SHARED_VIN";
+			rowA.bookingDate = "2026-03-01";
+			const rowB = createMockRow("2", undefined, "booking");
+			rowB.vin = "SHARED_VIN";
+			rowB.bookingDate = "2026-03-01";
+
+			const store = createTestStore([rowA, rowB]);
+			store.getState().checkNotifications();
+
+			const notifications = store
+				.getState()
+				.notifications.filter((n) => n.type === "booking_followup");
+			expect(notifications).toHaveLength(1);
+			const firstReferenceId = notifications[0].referenceId;
+
+			// Recompute again with the same underlying data — referenceId must not
+			// flap between rowA/rowB across polls.
+			store.getState().checkNotifications();
+			const secondPass = store
+				.getState()
+				.notifications.filter((n) => n.type === "booking_followup");
+			expect(secondPass).toHaveLength(1);
+			expect(secondPass[0].referenceId).toBe(firstReferenceId);
+		});
+
+		it("ignores booking follow-up logic for non-booking stage rows", () => {
+			const now = new Date(2026, 2, 2, 10, 0, 0);
+			vi.setSystemTime(now);
+
+			const row = createMockRow("1", undefined, "main");
+			row.bookingDate = "2026-03-01";
+
+			const store = createTestStore([row]);
+			store.getState().checkNotifications();
+
+			expect(
+				store
+					.getState()
+					.notifications.filter((n) => n.type === "booking_followup"),
+			).toHaveLength(0);
 		});
 	});
 
@@ -406,7 +550,7 @@ describe("notificationSlice", () => {
 			).toISOString();
 
 			const nonWarrantyRow: PendingRow = {
-				...createMockRow("row-5"),
+				...createMockRow("row-5", undefined, "main"),
 				repairSystem: "Other",
 				cntrRdg: 90_000,
 				createdAt,

--- a/src/test/notifications/notificationCandidatesRepository.test.ts
+++ b/src/test/notifications/notificationCandidatesRepository.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createNotificationCandidatesRepository } from "@/services/notifications/notificationCandidatesRepository";
+
+type Response = { data: unknown[] | null; error: null };
+
+/**
+ * A minimal thenable query-builder stub mirroring the real Supabase
+ * PostgrestFilterBuilder: every chain method returns `this` so calls can be
+ * chained in any order, and the object itself resolves via `.then` (so
+ * `await builder` works regardless of how many chain calls preceded it).
+ */
+function makeBuilder(response: Response) {
+	const calls: { method: string; args: unknown[] }[] = [];
+	// biome-ignore lint/suspicious/noExplicitAny: generic fluent test builder
+	const builder: any = { __calls: calls };
+	const methods = [
+		"select",
+		"neq",
+		"eq",
+		"not",
+		"lte",
+		"gte",
+		"filter",
+		"in",
+		"order",
+	];
+	for (const method of methods) {
+		builder[method] = vi.fn((...args: unknown[]) => {
+			calls.push({ method, args });
+			return builder;
+		});
+	}
+	// biome-ignore lint/suspicious/noThenProperty: intentional thenable stub mirroring Supabase's PostgrestFilterBuilder
+	builder.then = (
+		resolve: (value: Response) => void,
+		reject?: (reason: unknown) => void,
+	) => Promise.resolve(response).then(resolve, reject);
+	return builder;
+}
+
+/**
+ * Fake db client that hands out builders in the exact order the repository
+ * issues its queries: reminderIds, (reminders full-select if any ids),
+ * warranty, booking, cntr.
+ */
+function makeFakeDb(responses: Response[]) {
+	let call = 0;
+	const builders = responses.map(makeBuilder);
+	const from = vi.fn(() => {
+		const b = builders[call];
+		call += 1;
+		return b;
+	});
+	return { from, builders };
+}
+
+function orderRow(
+	id: string,
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		id,
+		stage: "orders",
+		order_number: `T${id}`,
+		customer_name: "Test User",
+		vin: `VIN${id}`,
+		metadata: {},
+		created_at: "2026-01-01T00:00:00.000Z",
+		order_reminders: [],
+		...overrides,
+	};
+}
+
+describe("notificationCandidatesRepository", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-20T12:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns an empty set with no candidates and no reminder ids found", async () => {
+		const { from } = makeFakeDb([
+			{ data: [], error: null }, // reminderIds
+			{ data: [], error: null }, // warranty
+			{ data: [], error: null }, // booking
+			{ data: [], error: null }, // cntr
+		]);
+
+		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used
+		const repo = createNotificationCandidatesRepository({ from } as any);
+		const result = await repo.getDueNotificationCandidates();
+
+		expect(result).toEqual([]);
+	});
+
+	it("dedupes a row that qualifies for multiple categories (reminder + warranty)", async () => {
+		const sharedRow = orderRow("shared-1", {
+			metadata: { endWarranty: "2026-06-01" },
+		});
+		const { from, builders } = makeFakeDb([
+			{ data: [{ id: "shared-1" }], error: null }, // reminderIds
+			{ data: [sharedRow], error: null }, // reminders full-select
+			{ data: [sharedRow], error: null }, // warranty (same row)
+			{ data: [], error: null }, // booking
+			{ data: [], error: null }, // cntr
+		]);
+
+		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used
+		const repo = createNotificationCandidatesRepository({ from } as any);
+		const result = await repo.getDueNotificationCandidates();
+
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("shared-1");
+		void builders;
+	});
+
+	it("returns the full unfiltered order_reminders embed for reminder candidates, not just the matching one", async () => {
+		// Two uncompleted reminders on the same order — the candidacy filter
+		// must not shape which ones come back for mapping (that decision
+		// belongs entirely to mapSupabaseOrder on the client, which picks
+		// "first uncompleted" — the server must return both).
+		const rowWithTwoReminders = orderRow("multi-reminder", {
+			order_reminders: [
+				{
+					id: "r1",
+					title: "First",
+					remind_at: "2026-05-19T00:00:00.000Z",
+					is_completed: false,
+				},
+				{
+					id: "r2",
+					title: "Second",
+					remind_at: "2026-05-20T00:00:00.000Z",
+					is_completed: false,
+				},
+			],
+		});
+		const { from } = makeFakeDb([
+			{ data: [{ id: "multi-reminder" }], error: null }, // reminderIds
+			{ data: [rowWithTwoReminders], error: null }, // reminders full-select
+			{ data: [], error: null }, // warranty
+			{ data: [], error: null }, // booking
+			{ data: [], error: null }, // cntr
+		]);
+
+		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used
+		const repo = createNotificationCandidatesRepository({ from } as any);
+		const result = await repo.getDueNotificationCandidates();
+
+		expect(result).toHaveLength(1);
+		const reminders = result[0].order_reminders as unknown[];
+		expect(reminders).toHaveLength(2);
+	});
+
+	it("skips the reminders full-select query entirely when no reminder ids are found", async () => {
+		const { from } = makeFakeDb([
+			{ data: [], error: null }, // reminderIds — empty
+			{ data: [], error: null }, // warranty
+			{ data: [], error: null }, // booking
+			{ data: [], error: null }, // cntr
+		]);
+
+		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used
+		const repo = createNotificationCandidatesRepository({ from } as any);
+		await repo.getDueNotificationCandidates();
+
+		// Exactly 4 `.from()` calls, not 5 — the second reminders query never runs.
+		expect(from).toHaveBeenCalledTimes(4);
+	});
+
+	it("includes a high-risk CNTR-RDG row aged 11 days (regression: the server bound must derive from the 10-day threshold, not the 14-day one)", async () => {
+		const highRiskRow = orderRow("cntr-high", {
+			stage: "main",
+			metadata: { repairSystem: "ضمان", cntrRdg: 90_000 },
+			created_at: new Date(Date.now() - 11 * 24 * 60 * 60 * 1000).toISOString(),
+		});
+		const { from, builders } = makeFakeDb([
+			{ data: [], error: null }, // reminderIds
+			{ data: [], error: null }, // warranty
+			{ data: [], error: null }, // booking
+			{ data: [highRiskRow], error: null }, // cntr
+		]);
+
+		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used
+		const repo = createNotificationCandidatesRepository({ from } as any);
+		const result = await repo.getDueNotificationCandidates();
+
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("cntr-high");
+
+		// The cutoff passed to the CNTR query's created_at filter must be no
+		// tighter than "9 days ago" — if it were "14 days ago" (the early-warning
+		// threshold), an 11-day-old high-risk row would have been excluded by
+		// Postgres before ever reaching the client's exact re-check.
+		const cntrBuilder = builders[3];
+		const lteCall = cntrBuilder.__calls.find(
+			(c: { method: string }) => c.method === "lte",
+		);
+		expect(lteCall).toBeDefined();
+		const cutoffArg = new Date(lteCall.args[1] as string);
+		const nineDaysAgo = new Date(Date.now() - 9 * 24 * 60 * 60 * 1000);
+		expect(cutoffArg.getTime()).toBeLessThanOrEqual(
+			nineDaysAgo.getTime() + 1000,
+		);
+		expect(cutoffArg.getTime()).toBeGreaterThan(
+			new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).getTime(),
+		);
+	});
+
+	it("orders every query deterministically by created_at then id", async () => {
+		const { from, builders } = makeFakeDb([
+			{ data: [], error: null },
+			{ data: [], error: null },
+			{ data: [], error: null },
+			{ data: [], error: null },
+		]);
+
+		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used
+		const repo = createNotificationCandidatesRepository({ from } as any);
+		await repo.getDueNotificationCandidates();
+
+		for (const builder of builders) {
+			const orderCalls = builder.__calls.filter(
+				(c: { method: string }) => c.method === "order",
+			);
+			expect(orderCalls.length).toBeGreaterThanOrEqual(2);
+			expect(orderCalls[0].args).toEqual(["created_at", { ascending: true }]);
+			expect(orderCalls[1].args).toEqual(["id", { ascending: true }]);
+		}
+	});
+
+	it("filters reminder candidacy without completed reminders due far in the future", async () => {
+		const { from, builders } = makeFakeDb([
+			{ data: [], error: null },
+			{ data: [], error: null },
+			{ data: [], error: null },
+			{ data: [], error: null },
+		]);
+
+		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used
+		const repo = createNotificationCandidatesRepository({ from } as any);
+		await repo.getDueNotificationCandidates();
+
+		const reminderIdsBuilder = builders[0];
+		const notCall = reminderIdsBuilder.__calls.find(
+			(c: { method: string }) => c.method === "not",
+		);
+		expect(notCall.args).toEqual(["order_reminders.is_completed", "eq", true]);
+		const neqCall = reminderIdsBuilder.__calls.find(
+			(c: { method: string }) => c.method === "neq",
+		);
+		expect(neqCall.args).toEqual(["stage", "archive"]);
+	});
+});

--- a/src/test/notifications/notificationCandidatesRepository.test.ts
+++ b/src/test/notifications/notificationCandidatesRepository.test.ts
@@ -39,9 +39,11 @@ function makeBuilder(response: Response) {
 }
 
 /**
- * Fake db client that hands out builders in the exact order the repository
- * issues its queries: reminderIds, (reminders full-select if any ids),
- * warranty, booking, cntr.
+ * Fake db client that hands out builders in `.from()` call order. Because the
+ * repository runs the reminder phase and the three single-stage queries under
+ * `Promise.all`, that order is: reminderIds, warranty, booking, cntr, and
+ * finally the reminders full-select (which only fires, after its own await, if
+ * the reminderIds query returned any ids).
  */
 function makeFakeDb(responses: Response[]) {
 	let call = 0;
@@ -100,12 +102,15 @@ describe("notificationCandidatesRepository", () => {
 		const sharedRow = orderRow("shared-1", {
 			metadata: { endWarranty: "2026-06-01" },
 		});
+		// Under Promise.all the `.from()` calls resolve in the order:
+		// reminderIds, warranty, booking, cntr, reminders-full (the reminder
+		// full-select fires after its own await resolves).
 		const { from, builders } = makeFakeDb([
 			{ data: [{ id: "shared-1" }], error: null }, // reminderIds
-			{ data: [sharedRow], error: null }, // reminders full-select
 			{ data: [sharedRow], error: null }, // warranty (same row)
 			{ data: [], error: null }, // booking
 			{ data: [], error: null }, // cntr
+			{ data: [sharedRow], error: null }, // reminders full-select
 		]);
 
 		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used
@@ -140,10 +145,10 @@ describe("notificationCandidatesRepository", () => {
 		});
 		const { from } = makeFakeDb([
 			{ data: [{ id: "multi-reminder" }], error: null }, // reminderIds
-			{ data: [rowWithTwoReminders], error: null }, // reminders full-select
 			{ data: [], error: null }, // warranty
 			{ data: [], error: null }, // booking
 			{ data: [], error: null }, // cntr
+			{ data: [rowWithTwoReminders], error: null }, // reminders full-select
 		]);
 
 		// biome-ignore lint/suspicious/noExplicitAny: fake db satisfies the subset used

--- a/src/test/notifications/notificationCandidatesService.test.ts
+++ b/src/test/notifications/notificationCandidatesService.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchDueNotificationCandidates } from "@/services/notifications/notificationCandidatesService";
+
+const mockFetch = vi.fn();
+
+function makeOrderRow(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		stage: "orders",
+		order_number: `T${id}`,
+		customer_name: "Test User",
+		customer_email: null,
+		customer_phone: "123",
+		vin: `VIN${id}`,
+		company: null,
+		status: "pending",
+		metadata: {
+			baseId: `B${id}`,
+			cntrRdg: 0,
+			model: "Test",
+			parts: [],
+			sabNumber: "S1",
+			acceptedBy: "User",
+			requester: "User",
+			partNumber: "P1",
+			description: "Desc",
+			quantity: 1,
+			status: "Orders",
+			rDate: "2024-01-01",
+			repairSystem: "None",
+			startWarranty: "",
+			endWarranty: "",
+			remainTime: "",
+		},
+		created_at: "2026-01-01T00:00:00.000Z",
+		updated_at: "2026-01-01T00:00:00.000Z",
+		order_reminders: [],
+		...overrides,
+	};
+}
+
+describe("fetchDueNotificationCandidates", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", mockFetch);
+		mockFetch.mockReset();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("maps candidate rows through mapSupabaseOrder", async () => {
+		mockFetch.mockResolvedValue({
+			ok: true,
+			json: async () => ({ candidates: [makeOrderRow("1")] }),
+		});
+
+		const rows = await fetchDueNotificationCandidates();
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0].id).toBe("1");
+		expect(rows[0].vin).toBe("VIN1");
+	});
+
+	it("throws (rather than silently skipping) when a row fails mapping", async () => {
+		// order_number missing / malformed metadata causing a schema validation
+		// failure inside mapSupabaseOrder. This must propagate so React Query
+		// keeps the previous good candidate set instead of the notification
+		// engine seeing a partial one and wrongly pruning dismissed keys.
+		const badRow = makeOrderRow("bad", { metadata: null, id: undefined });
+
+		mockFetch.mockResolvedValue({
+			ok: true,
+			json: async () => ({ candidates: [badRow] }),
+		});
+
+		await expect(fetchDueNotificationCandidates()).rejects.toThrow();
+	});
+
+	it("throws when the response is not ok", async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 401,
+			json: async () => ({ error: "Unauthorized" }),
+		});
+
+		await expect(fetchDueNotificationCandidates()).rejects.toThrow(
+			"Unauthorized",
+		);
+	});
+});

--- a/src/test/useOrdersRealtimeSync.test.ts
+++ b/src/test/useOrdersRealtimeSync.test.ts
@@ -5,8 +5,13 @@ import { useOrdersRealtimeSync } from "@/hooks/useOrdersRealtimeSync";
 // --- Mocks ---
 
 const mockInvalidateQueries = vi.fn();
+// Stable object identity across renders — a fresh object per call would make
+// the channel effect's `[queryClient]` dependency appear to change every
+// render, causing spurious channel re-creation that the tests below would
+// otherwise misattribute to the hook itself.
+const mockQueryClient = { invalidateQueries: mockInvalidateQueries };
 vi.mock("@tanstack/react-query", () => ({
-	useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+	useQueryClient: () => mockQueryClient,
 }));
 
 vi.mock("@/lib/queryClient", () => ({
@@ -16,17 +21,21 @@ vi.mock("@/lib/queryClient", () => ({
 
 let capturedInsertCallback: (() => void) | null = null;
 const mockRemoveChannel = vi.fn().mockResolvedValue(undefined);
+const mockChannel = vi.fn();
 
 vi.mock("@/lib/supabase-browser", () => ({
 	getSupabaseBrowserClient: () => ({
-		channel: () => ({
-			on: (_event: string, _filter: unknown, cb: () => void) => {
-				capturedInsertCallback = cb;
-				return {
-					subscribe: () => ({}),
-				};
-			},
-		}),
+		channel: (...args: unknown[]) => {
+			mockChannel(...args);
+			return {
+				on: (_event: string, _filter: unknown, cb: () => void) => {
+					capturedInsertCallback = cb;
+					return {
+						subscribe: () => ({}),
+					};
+				},
+			};
+		},
 		removeChannel: mockRemoveChannel,
 	}),
 }));
@@ -49,6 +58,44 @@ describe("useOrdersRealtimeSync", () => {
 		vi.clearAllMocks();
 		capturedInsertCallback = null;
 		mockIsDraftActive = false;
+	});
+
+	it("creates the realtime channel exactly once across draft-session toggles", () => {
+		mockIsDraftActive = false;
+		const { rerender } = renderHook(() => useOrdersRealtimeSync());
+		expect(mockChannel).toHaveBeenCalledTimes(1);
+
+		// Enter a draft session
+		mockIsDraftActive = true;
+		rerender();
+		expect(mockChannel).toHaveBeenCalledTimes(1);
+		expect(mockRemoveChannel).not.toHaveBeenCalled();
+
+		// Exit the draft session
+		mockIsDraftActive = false;
+		rerender();
+		expect(mockChannel).toHaveBeenCalledTimes(1);
+		expect(mockRemoveChannel).not.toHaveBeenCalled();
+	});
+
+	it("reads the current draft state via ref so an INSERT right after a draft ends invalidates immediately", () => {
+		mockIsDraftActive = true;
+		const { rerender } = renderHook(() => useOrdersRealtimeSync());
+
+		// Draft ends
+		mockIsDraftActive = false;
+		rerender();
+		mockInvalidateQueries.mockClear();
+
+		// INSERT arrives after the draft ended — the ref must reflect the
+		// latest value even though the channel (and its closure) was created
+		// while the draft was still active.
+		act(() => {
+			capturedInsertCallback?.();
+		});
+
+		expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+		expect(mockToastInfo).not.toHaveBeenCalled();
 	});
 
 	it("invalidates orders query immediately on INSERT when draft is inactive", () => {


### PR DESCRIPTION
## Summary

- **MAH-40** — Stop tearing down/recreating the Supabase realtime channel on every draft-session toggle. `isDraftActive` is now read via a ref inside the INSERT callback (mirroring `useWarrantyExpiryMaintenance`), so the channel effect no longer depends on it.
- **MAH-39** — Move notification-candidate selection server-side. A new `GET /api/notifications` route queries `orders`/`order_reminders` with loose superset filters and returns a small candidate set; `checkNotifications` now reads that set through the existing `OrdersQueryAdapter` port instead of scanning four per-stage caches. Reminders/warranties/booking follow-ups/CNTR-RDG warnings now surface for stages the user never opened, and dismissed-key pruning depends on the candidate cache instead of every per-stage `isStageLoaded()` flag. Reminder mapping (and managedKey construction) stays entirely client-side to preserve dismissed-key continuity across timezones.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` (Biome) — clean on all changed files
- [x] `npm run test` — 675/675 tests pass across 69 files, including new coverage: realtime-channel stability, server candidate repository (loose-superset filters, deterministic ordering, unfiltered reminder embed, CNTR high-risk regression), API route auth, client mapping-failure policy, and notification-slice behavior for unopened/evicted stages
- [x] `npm run build` — production build succeeds; `/api/notifications` registers as a dynamic route
- [ ] Manual: hit `GET /api/notifications` authenticated and confirm due candidates appear independent of which stage pages were visited
- [ ] Manual: toggle a draft session while watching the browser WS panel to confirm the realtime channel doesn't reconnect (not run in this session — no live Supabase credentials in this sandbox)

Closes MAH-39, MAH-40.


---
_Generated by [Claude Code](https://claude.ai/code/session_016e7M5JeYAyxsCyTEDf3dJA)_