### PR TITLE
Preserve External Links in reorder audit trail (MAH-47)

### DIFF
--- a/src/components/shared/search/hooks/useSearchResultsState.ts
+++ b/src/components/shared/search/hooks/useSearchResultsState.ts
@@ -31,6 +31,7 @@ import { useRowModals } from "@/hooks/useRowModals";
 import { exportToLogisticsXLSX } from "@/lib/exportUtils";
 import { logger } from "@/lib/logger";
 import { normalizeOrderStage } from "@/lib/orderStage";
+import { buildReorderCommands } from "@/lib/orderStageTransitions";
 import { printReservationLabels } from "@/lib/printing/reservationLabels";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
@@ -487,16 +488,14 @@ export const useSearchResultsState = () => {
 			const results = await Promise.allSettled(
 				selectedRows.map((row) => {
 					const freshRow = searchResults.find((r) => r.id === row.id) ?? row;
+					const [{ updates }] = buildReorderCommands(
+						[freshRow],
+						row.stage as OrderStage,
+						reorderReason,
+					);
 					return saveOrderMutation.mutateAsync({
 						id: row.id,
-						updates: {
-							status: "Reorder",
-							noteHistory: appendTaggedUserNote(
-								getEffectiveNoteHistory(freshRow),
-								`Reorder Reason: ${reorderReason}`,
-								"reorder",
-							),
-						},
+						updates,
 						stage: "orders",
 						sourceStage: row.stage as OrderStage,
 					});

--- a/src/components/shared/search/hooks/useSearchResultsState.ts
+++ b/src/components/shared/search/hooks/useSearchResultsState.ts
@@ -31,7 +31,7 @@ import { useRowModals } from "@/hooks/useRowModals";
 import { exportToLogisticsXLSX } from "@/lib/exportUtils";
 import { logger } from "@/lib/logger";
 import { normalizeOrderStage } from "@/lib/orderStage";
-import { buildReorderCommands } from "@/lib/orderStageTransitions";
+import { buildReorderUpdates } from "@/lib/orderStageTransitions";
 import { printReservationLabels } from "@/lib/printing/reservationLabels";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
@@ -488,14 +488,9 @@ export const useSearchResultsState = () => {
 			const results = await Promise.allSettled(
 				selectedRows.map((row) => {
 					const freshRow = searchResults.find((r) => r.id === row.id) ?? row;
-					const [{ updates }] = buildReorderCommands(
-						[freshRow],
-						row.stage as OrderStage,
-						reorderReason,
-					);
 					return saveOrderMutation.mutateAsync({
 						id: row.id,
-						updates,
+						updates: buildReorderUpdates(freshRow, reorderReason),
 						stage: "orders",
 						sourceStage: row.stage as OrderStage,
 					});

--- a/src/lib/orderStageTransitions.ts
+++ b/src/lib/orderStageTransitions.ts
@@ -4,6 +4,7 @@ import {
 	getEffectiveNoteHistory,
 } from "@/domain/order/orderWorkflow";
 import { buildArchivePayload } from "@/lib/archivePayloadBuilder";
+import { hasAttachment } from "@/lib/attachment";
 import type { PatchRowCommand, PendingRow } from "@/types";
 import { safeFormatDate } from "@/utils/safeFormatDate";
 
@@ -35,6 +36,13 @@ export function buildSendToArchiveCommands(
 /**
  * Returns patchRow commands to send rows back to the Orders stage with
  * status "Reorder" and the reason appended to the note history.
+ *
+ * When a row carries an External Link attachment (`attachmentLink`), the link is
+ * preserved into the note history and then cleared from the attachment. This
+ * keeps the previous link reviewable in the audit trail while giving the
+ * reordered line a clean External Link field for its next round — otherwise the
+ * link the operator later attaches on the way back to Main Sheet would silently
+ * overwrite the old one (MAH-47). Uploaded file attachments are left untouched.
  */
 export function buildReorderCommands(
 	rows: PendingRow[],
@@ -42,17 +50,38 @@ export function buildReorderCommands(
 	reason: string,
 ): PatchRowCommand[] {
 	return rows.map((row) => {
-		const newNoteHistory = appendTaggedUserNote(
+		let newNoteHistory = appendTaggedUserNote(
 			getEffectiveNoteHistory(row),
 			`Reorder Reason: ${reason}`,
 			"reorder",
 		);
+
+		const previousLink = row.attachmentLink?.trim();
+		const attachmentUpdates: Partial<PendingRow> = {};
+		if (previousLink) {
+			newNoteHistory = appendTaggedUserNote(
+				newNoteHistory,
+				`Previous link: ${previousLink}`,
+				"reorder",
+			);
+			attachmentUpdates.attachmentLink = "";
+			attachmentUpdates.hasAttachment = hasAttachment({
+				attachmentLink: "",
+				attachmentFilePath: row.attachmentFilePath,
+				attachmentFilePaths: row.attachmentFilePaths,
+			});
+		}
+
 		return {
 			type: "patchRow",
 			id: row.id,
 			sourceStage,
 			destinationStage: "orders" as const,
-			updates: { noteHistory: newNoteHistory, status: "Reorder" },
+			updates: {
+				noteHistory: newNoteHistory,
+				status: "Reorder",
+				...attachmentUpdates,
+			},
 			previousValues: {},
 		};
 	});

--- a/src/lib/orderStageTransitions.ts
+++ b/src/lib/orderStageTransitions.ts
@@ -4,12 +4,27 @@ import {
 	getEffectiveNoteHistory,
 } from "@/domain/order/orderWorkflow";
 import { buildArchivePayload } from "@/lib/archivePayloadBuilder";
-import { hasAttachment } from "@/lib/attachment";
+import { hasAttachment, sanitizeAttachmentLink } from "@/lib/attachment";
 import type { PatchRowCommand, PendingRow } from "@/types";
 import { safeFormatDate } from "@/utils/safeFormatDate";
 
 /** Matches the BOOKING column display format on the Archive/Booking pages. */
 const BOOKING_DATE_FORMAT = "EEE, MMM d, yyyy";
+
+/**
+ * Appends a `<label>: <value> #<tag>` line to note history, recording a value
+ * that is about to be overwritten so it stays reviewable in the audit trail.
+ * No-op when `value` is empty.
+ */
+function appendPreviousValueNote(
+	history: string,
+	label: string,
+	value: string | undefined,
+	tag: string,
+): string {
+	if (!value) return history;
+	return appendTaggedUserNote(history, `${label}: ${value}`, tag);
+}
 
 /**
  * Returns patchRow commands to archive the given rows.
@@ -44,47 +59,53 @@ export function buildSendToArchiveCommands(
  * link the operator later attaches on the way back to Main Sheet would silently
  * overwrite the old one (MAH-47). Uploaded file attachments are left untouched.
  */
+export function buildReorderUpdates(
+	row: PendingRow,
+	reason: string,
+): Partial<PendingRow> {
+	let newNoteHistory = appendTaggedUserNote(
+		getEffectiveNoteHistory(row),
+		`Reorder Reason: ${reason}`,
+		"reorder",
+	);
+
+	const previousLink = sanitizeAttachmentLink(row.attachmentLink ?? "");
+	newNoteHistory = appendPreviousValueNote(
+		newNoteHistory,
+		"Previous link",
+		previousLink,
+		"reorder",
+	);
+
+	const attachmentUpdates: Partial<PendingRow> = {};
+	if (previousLink) {
+		attachmentUpdates.attachmentLink = "";
+		attachmentUpdates.hasAttachment = hasAttachment({
+			attachmentFilePath: row.attachmentFilePath,
+			attachmentFilePaths: row.attachmentFilePaths,
+		});
+	}
+
+	return {
+		noteHistory: newNoteHistory,
+		status: "Reorder",
+		...attachmentUpdates,
+	};
+}
+
 export function buildReorderCommands(
 	rows: PendingRow[],
 	sourceStage: OrderStage,
 	reason: string,
 ): PatchRowCommand[] {
-	return rows.map((row) => {
-		let newNoteHistory = appendTaggedUserNote(
-			getEffectiveNoteHistory(row),
-			`Reorder Reason: ${reason}`,
-			"reorder",
-		);
-
-		const previousLink = row.attachmentLink?.trim();
-		const attachmentUpdates: Partial<PendingRow> = {};
-		if (previousLink) {
-			newNoteHistory = appendTaggedUserNote(
-				newNoteHistory,
-				`Previous link: ${previousLink}`,
-				"reorder",
-			);
-			attachmentUpdates.attachmentLink = "";
-			attachmentUpdates.hasAttachment = hasAttachment({
-				attachmentLink: "",
-				attachmentFilePath: row.attachmentFilePath,
-				attachmentFilePaths: row.attachmentFilePaths,
-			});
-		}
-
-		return {
-			type: "patchRow",
-			id: row.id,
-			sourceStage,
-			destinationStage: "orders" as const,
-			updates: {
-				noteHistory: newNoteHistory,
-				status: "Reorder",
-				...attachmentUpdates,
-			},
-			previousValues: {},
-		};
-	});
+	return rows.map((row) => ({
+		type: "patchRow",
+		id: row.id,
+		sourceStage,
+		destinationStage: "orders" as const,
+		updates: buildReorderUpdates(row, reason),
+		previousValues: {},
+	}));
 }
 
 /**
@@ -108,19 +129,17 @@ export function buildBookingCommands(
 		// note history before it is overwritten, so past appointments remain
 		// reviewable. Wording stays neutral ("Previous booking") because nothing
 		// clears bookingDate — the prior appointment may also have been kept.
-		let history = getEffectiveNoteHistory(row);
 		const previousDate = safeFormatDate(
 			row.bookingDate?.trim() || null,
 			BOOKING_DATE_FORMAT,
 			"",
 		);
-		if (previousDate) {
-			history = appendTaggedUserNote(
-				history,
-				`Previous booking: ${previousDate}.`,
-				"rebooking",
-			);
-		}
+		const history = appendPreviousValueNote(
+			getEffectiveNoteHistory(row),
+			"Previous booking",
+			previousDate ? `${previousDate}.` : undefined,
+			"rebooking",
+		);
 		const newNoteHistory = appendTaggedUserNote(history, note, "booking");
 		return {
 			type: "patchRow",

--- a/src/test/orderStageTransitions.test.ts
+++ b/src/test/orderStageTransitions.test.ts
@@ -103,6 +103,37 @@ describe("buildReorderCommands", () => {
 		const [cmd] = buildReorderCommands([createMockRow()], "booking", "test");
 		expect(cmd.previousValues).toEqual({});
 	});
+
+	it("does not touch attachment fields when the row has no External Link", () => {
+		const [cmd] = buildReorderCommands([createMockRow()], "main", "no stock");
+		expect("attachmentLink" in cmd.updates).toBe(false);
+		expect("hasAttachment" in cmd.updates).toBe(false);
+	});
+
+	it("preserves the External Link into the note history and clears it", () => {
+		const row = createMockRow({
+			attachmentLink: "https://example.com/old-link",
+			hasAttachment: true,
+		});
+		const [cmd] = buildReorderCommands([row], "main", "no stock");
+		expect(cmd.updates.attachmentLink).toBe("");
+		expect(cmd.updates.hasAttachment).toBe(false);
+		expect(cmd.updates.noteHistory).toContain("Reorder Reason: no stock");
+		expect(cmd.updates.noteHistory).toContain(
+			"Previous link: https://example.com/old-link",
+		);
+	});
+
+	it("keeps hasAttachment true when uploaded files remain after clearing the link", () => {
+		const row = createMockRow({
+			attachmentLink: "https://example.com/old-link",
+			attachmentFilePaths: ["orders/row-uuid-1/invoice.pdf"],
+			hasAttachment: true,
+		});
+		const [cmd] = buildReorderCommands([row], "call", "wrong part");
+		expect(cmd.updates.attachmentLink).toBe("");
+		expect(cmd.updates.hasAttachment).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
When reordering a row, External Link attachments are now preserved in the note history before being cleared. This maintains an audit trail of the previous link while giving the reordered line a clean External Link field for its next round, preventing silent overwrites when operators attach a new link on the way back to Main Sheet.

## Changes
- **`src/lib/orderStageTransitions.ts`**
  - Updated `buildReorderCommands()` to detect and handle External Link attachments
  - When a row has an `attachmentLink`, it is appended to the note history with a "Previous link:" tag and then cleared
  - The `hasAttachment` flag is recalculated after clearing the link to account for any remaining uploaded file attachments
  - Uploaded file attachments (`attachmentFilePath`, `attachmentFilePaths`) are left untouched
  - Added import for `hasAttachment` utility function

- **`src/test/orderStageTransitions.test.ts`**
  - Added three new test cases:
    - Verifies attachment fields are not touched when no External Link exists
    - Confirms External Link is preserved in note history and cleared from the row
    - Ensures `hasAttachment` remains `true` when uploaded files exist after clearing the link

- **`src/components/shared/search/hooks/useSearchResultsState.ts`**
  - Refactored reorder logic to use `buildReorderCommands()` instead of duplicating command construction
  - Eliminates inline note history building and ensures consistency with the main reorder flow

## Implementation Details
The `hasAttachment` recalculation uses the existing utility function to properly evaluate the attachment state based on remaining file attachments, ensuring the flag accurately reflects whether the row has any attachments after the link is cleared.

https://claude.ai/code/session_013BkdVKYFHPqJb1tm6yjBL6