### PR TITLE
Drop unique constraint on orders.order_number

### DIFF
--- a/supabase/migrations/20260728_drop_orders_order_number_unique.sql
+++ b/supabase/migrations/20260728_drop_orders_order_number_unique.sql
@@ -1,0 +1,11 @@
+-- Every part of an order is stored as its own row, and those rows share the
+-- order's order_number by design. UNIQUE(order_number) therefore rejected every
+-- attempt to add a part to an order that already existed:
+--   duplicate key value violates unique constraint "orders_order_number_key"
+--
+-- order_number is system-generated and read for display only (global search,
+-- the XLSX export, the recent_activity trigger label) — nothing looks a row up
+-- by it, and the non-unique idx_orders_order_number already covers that column,
+-- so dropping the unique index costs nothing.
+ALTER TABLE public.orders
+  DROP CONSTRAINT IF EXISTS orders_order_number_key;


### PR DESCRIPTION
## Summary
Removes the `UNIQUE` constraint on the `order_number` column in the `orders` table to allow multiple rows (parts) to share the same order number.

## Key Changes
- Drops the `orders_order_number_key` unique constraint via migration
- Retains the non-unique `idx_orders_order_number` index for query performance on display and search operations

## Implementation Details
The unique constraint was preventing parts from being added to existing orders, since each part is stored as its own row sharing the order's `order_number`. The `order_number` is system-generated and used only for display (global search, XLSX export, activity labels) — no lookups depend on it being unique. The existing non-unique index provides sufficient performance for these read-only use cases.

https://claude.ai/code/session_01HmxJBBZAybtwK3cGaZXuzX