### PR TITLE
Fix notification jump to live stage (wrong tab)

### DIFF
--- a/src/components/grid/DataGrid.tsx
+++ b/src/components/grid/DataGrid.tsx
@@ -140,7 +140,7 @@ function DataGridInner<T extends { id?: string; vin?: string }>({
 		handleLayoutChange();
 	}, [gridStateKey, setPositionLayoutDirty, handleLayoutChange]);
 
-	// Scroll to highlighted row
+	// Scroll to highlighted row (stage-scoped — ignore requests for other stages)
 	const highlightedRowId = useAppStore((state) => state.highlightedRowId);
 	const setHighlightedRowId = useAppStore((state) => state.setHighlightedRowId);
 	const pendingHighlightRef = useRef<string | null>(null);
@@ -159,17 +159,17 @@ function DataGridInner<T extends { id?: string; vin?: string }>({
 
 	// Register intent when highlight requests arrive, and trigger jump
 	useEffect(() => {
-		if (!highlightedRowId) return;
+		if (!highlightedRowId || !stage || highlightedRowId.stage !== stage) return;
 
-		pendingHighlightRef.current = highlightedRowId;
+		pendingHighlightRef.current = highlightedRowId.id;
 		attemptJump();
-	}, [highlightedRowId, attemptJump, rowData]);
+	}, [highlightedRowId, attemptJump, rowData, stage]);
 
 	// Guard against unresolvable requests (fallback timeout)
 	useEffect(() => {
-		if (!highlightedRowId) return;
+		if (!highlightedRowId || !stage || highlightedRowId.stage !== stage) return;
 
-		const requestedId = highlightedRowId;
+		const requestedId = highlightedRowId.id;
 
 		const timeout = setTimeout(() => {
 			if (pendingHighlightRef.current === requestedId) {
@@ -180,7 +180,7 @@ function DataGridInner<T extends { id?: string; vin?: string }>({
 		}, 8000);
 
 		return () => clearTimeout(timeout);
-	}, [highlightedRowId, setHighlightedRowId]);
+	}, [highlightedRowId, setHighlightedRowId, stage]);
 
 	// Wire search badge navigation for this stage
 	const attemptPendingSelect = usePendingSearchSelection(

--- a/src/components/shared/NotificationsDropdown.tsx
+++ b/src/components/shared/NotificationsDropdown.tsx
@@ -4,9 +4,27 @@ import { AnimatePresence, motion } from "framer-motion";
 import { Bell, Hash, MapPin, TableProperties, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { toast } from "sonner";
+import type { OrderStage } from "@/domain/order/orderStage";
+import { ORDER_STAGES } from "@/lib/constants";
+import { ORDER_STAGE_TAB_INFO } from "@/lib/orderStage";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/store/useStore";
 import type { AppNotification } from "@/types";
+
+/** Resolve which stage currently holds the order (draft overlay or persisted cache). */
+export function resolveNotificationStage(
+	referenceId: string,
+): OrderStage | undefined {
+	const getWorkingRows = useAppStore.getState().getWorkingRows;
+	for (const stage of ORDER_STAGES) {
+		const rows = getWorkingRows(stage);
+		if (rows?.some((row) => row.id === referenceId)) {
+			return stage;
+		}
+	}
+	return undefined;
+}
 
 export const NotificationsDropdown = () => {
 	const router = useRouter();
@@ -36,8 +54,15 @@ export const NotificationsDropdown = () => {
 			return;
 		}
 
-		if (n.path) router.push(n.path);
-		setHighlightedRowId(n.referenceId);
+		const resolvedStage = resolveNotificationStage(n.referenceId);
+		if (!resolvedStage) {
+			toast.error("Order no longer available");
+			setShowNotifications(false);
+			return;
+		}
+
+		router.push(ORDER_STAGE_TAB_INFO[resolvedStage].path);
+		setHighlightedRowId({ stage: resolvedStage, id: n.referenceId });
 		setShowNotifications(false);
 	};
 

--- a/src/lib/orderStage.ts
+++ b/src/lib/orderStage.ts
@@ -10,6 +10,18 @@ const STAGE_ALIASES: Record<string, OrderStage> = {
 	orders: "orders",
 };
 
+/** Display name and app route for each operational stage. */
+export const ORDER_STAGE_TAB_INFO: Record<
+	OrderStage,
+	{ name: string; path: string }
+> = {
+	orders: { name: "Orders", path: "/orders" },
+	main: { name: "Main Sheet", path: "/main-sheet" },
+	call: { name: "Call List", path: "/call-list" },
+	booking: { name: "Booking", path: "/booking" },
+	archive: { name: "Archive", path: "/archive" },
+};
+
 export function normalizeOrderStage(
 	value: string | null | undefined,
 ): OrderStage | undefined {

--- a/src/store/slices/notificationSlice.ts
+++ b/src/store/slices/notificationSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from "zustand";
+import { ORDER_STAGE_TAB_INFO } from "@/lib/orderStage";
 import { generateId } from "@/lib/utils";
 import type { AppNotification, PendingRow } from "@/types";
 import { getOrdersQueryAdapter } from "../ordersQueryAdapter";
@@ -7,13 +8,6 @@ import type {
 	NotificationActions,
 	NotificationState,
 } from "../types";
-
-const STAGE_TAB_INFO: Record<string, { name: string; path: string }> = {
-	main: { name: "Main Sheet", path: "/main-sheet" },
-	orders: { name: "Orders", path: "/orders" },
-	booking: { name: "Booking", path: "/booking" },
-	call: { name: "Call List", path: "/call-list" },
-};
 
 export const createNotificationSlice: StateCreator<
 	CombinedStore,
@@ -104,7 +98,7 @@ export const createNotificationSlice: StateCreator<
 		const activeManagedKeys = new Set<string>();
 
 		for (const row of rows) {
-			const tabInfo = row.stage ? STAGE_TAB_INFO[row.stage] : undefined;
+			const tabInfo = row.stage ? ORDER_STAGE_TAB_INFO[row.stage] : undefined;
 			const tabName = tabInfo?.name ?? "Orders";
 			const path = tabInfo?.path ?? "/orders";
 

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -53,8 +53,8 @@ export const createUISlice: StateCreator<
 
 	setSearchTerm: (term) => set({ searchTerm: term }),
 
-	setHighlightedRowId: (id) => {
-		set({ highlightedRowId: id });
+	setHighlightedRowId: (request) => {
+		set({ highlightedRowId: request });
 	},
 
 	setPendingVinSelection: (vin) => set({ pendingVinSelection: vin }),

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -34,7 +34,8 @@ export interface NotificationActions {
 
 export interface UIState {
 	searchTerm: string;
-	highlightedRowId: string | null;
+	/** Stage-scoped row jump request (notification click). Only the matching stage grid may consume it. */
+	highlightedRowId: { stage: OrderStage; id: string } | null;
 	pendingVinSelection: { vin: string; bookingDate?: string } | string | null;
 	notes: StickyNote[];
 	partStatuses: PartStatusDef[];
@@ -49,7 +50,9 @@ export interface UIState {
 
 export interface UIActions {
 	setSearchTerm: (term: string) => void;
-	setHighlightedRowId: (id: string | null) => void;
+	setHighlightedRowId: (
+		request: { stage: OrderStage; id: string } | null,
+	) => void;
 	setPendingVinSelection: (
 		vin: { vin: string; bookingDate?: string } | string | null,
 	) => void;

--- a/src/test/DataGrid.test.tsx
+++ b/src/test/DataGrid.test.tsx
@@ -56,3 +56,28 @@ describe("DataGrid layout restoration", () => {
 		expect(lastAgGridProps?.initialState).toEqual(defaultState);
 	});
 });
+
+describe("DataGrid stage-scoped jump request", () => {
+	beforeEach(() => {
+		lastAgGridProps = null;
+		useAppStore.setState({
+			highlightedRowId: { stage: "call", id: "row-1" },
+		});
+	});
+
+	it("ignores a jump request addressed to another stage and leaves it pending", () => {
+		render(
+			<DataGrid
+				rowData={[]}
+				columnDefs={[]}
+				gridStateKey="main"
+				stage="main"
+			/>,
+		);
+
+		expect(useAppStore.getState().highlightedRowId).toEqual({
+			stage: "call",
+			id: "row-1",
+		});
+	});
+});

--- a/src/test/NotificationsDropdown.test.tsx
+++ b/src/test/NotificationsDropdown.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OrderStage } from "@/domain/order/orderStage";
+import { useAppStore } from "@/store/useStore";
+import type { AppNotification, PendingRow } from "@/types";
+
+const routerPush = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: routerPush }),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { error: (...args: unknown[]) => toastError(...args) },
+}));
+
+vi.mock("framer-motion", () => ({
+	AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+		<>{children}</>
+	),
+	motion: {
+		div: ({
+			children,
+			...props
+		}: React.HTMLAttributes<HTMLDivElement> & {
+			children?: React.ReactNode;
+		}) => <div {...props}>{children}</div>,
+	},
+}));
+
+import {
+	NotificationsDropdown,
+	resolveNotificationStage,
+} from "@/components/shared/NotificationsDropdown";
+
+const createRow = (id: string, stage: OrderStage): PendingRow =>
+	({
+		id,
+		baseId: `B${id}`,
+		trackingId: `T${id}`,
+		customerName: "Test",
+		vin: `VIN${id}`,
+		mobile: "123",
+		cntrRdg: 0,
+		model: "M",
+		parts: [],
+		sabNumber: "",
+		acceptedBy: "",
+		requester: "",
+		partNumber: "P1",
+		description: "D",
+		quantity: 1,
+		status: "",
+		rDate: "",
+		repairSystem: "",
+		startWarranty: "",
+		endWarranty: "",
+		remainTime: "",
+		stage,
+	}) as PendingRow;
+
+const createReminderNotification = (
+	overrides: Partial<AppNotification> = {},
+): AppNotification => ({
+	id: "notif-1",
+	type: "reminder",
+	title: "Reminder Due",
+	description: "Due",
+	referenceId: "row-1",
+	vin: "VIN1",
+	trackingId: "T1",
+	tabName: "Main Sheet",
+	path: "/main-sheet",
+	timestamp: new Date().toISOString(),
+	isRead: false,
+	managedKey: "reminder:row-1:2026-01-01:10:00:x",
+	...overrides,
+});
+
+function stubWorkingRows(byStage: Partial<Record<OrderStage, PendingRow[]>>) {
+	useAppStore.setState({
+		getWorkingRows: (stage: OrderStage) => byStage[stage] ?? [],
+	});
+}
+
+describe("resolveNotificationStage", () => {
+	beforeEach(() => {
+		stubWorkingRows({});
+	});
+
+	it("finds the stage that currently holds the row (draft move main→call)", () => {
+		stubWorkingRows({
+			main: [],
+			call: [createRow("row-1", "call")],
+		});
+		expect(resolveNotificationStage("row-1")).toBe("call");
+	});
+
+	it("finds the saved stage even when notification still stamped main", () => {
+		stubWorkingRows({
+			main: [],
+			call: [createRow("row-1", "call")],
+		});
+		expect(resolveNotificationStage("row-1")).toBe("call");
+	});
+
+	it("returns undefined when the row is missing from every stage", () => {
+		stubWorkingRows({
+			main: [createRow("other", "main")],
+		});
+		expect(resolveNotificationStage("row-1")).toBeUndefined();
+	});
+});
+
+describe("NotificationsDropdown click-time navigation", () => {
+	beforeEach(() => {
+		routerPush.mockReset();
+		toastError.mockReset();
+		useAppStore.setState({
+			notifications: [createReminderNotification()],
+			highlightedRowId: null,
+			markNotificationAsRead: vi.fn(),
+			clearNotifications: vi.fn(),
+			removeNotification: vi.fn(),
+			setPendingVinSelection: vi.fn(),
+		});
+		stubWorkingRows({});
+	});
+
+	async function openAndClickNotification() {
+		const user = userEvent.setup();
+		render(<NotificationsDropdown />);
+		await user.click(screen.getByTitle("Notifications"));
+		await user.click(screen.getByText("Reminder Due"));
+	}
+
+	it("navigates to /call-list when the live stage is call (draft move)", async () => {
+		stubWorkingRows({
+			main: [],
+			call: [createRow("row-1", "call")],
+		});
+
+		await openAndClickNotification();
+
+		expect(routerPush).toHaveBeenCalledWith("/call-list");
+		expect(useAppStore.getState().highlightedRowId).toEqual({
+			stage: "call",
+			id: "row-1",
+		});
+		expect(toastError).not.toHaveBeenCalled();
+	});
+
+	it("navigates to /call-list when notification path is still /main-sheet after a saved move", async () => {
+		useAppStore.setState({
+			notifications: [
+				createReminderNotification({
+					path: "/main-sheet",
+					tabName: "Main Sheet",
+				}),
+			],
+		});
+		stubWorkingRows({
+			call: [createRow("row-1", "call")],
+		});
+
+		await openAndClickNotification();
+
+		expect(routerPush).toHaveBeenCalledWith("/call-list");
+		expect(routerPush).not.toHaveBeenCalledWith("/main-sheet");
+		expect(useAppStore.getState().highlightedRowId).toEqual({
+			stage: "call",
+			id: "row-1",
+		});
+	});
+
+	it("skips navigation and toasts when the row is not in any stage", async () => {
+		stubWorkingRows({});
+
+		await openAndClickNotification();
+
+		expect(routerPush).not.toHaveBeenCalled();
+		expect(useAppStore.getState().highlightedRowId).toBeNull();
+		expect(toastError).toHaveBeenCalledWith("Order no longer available");
+	});
+
+	it("leaves booking_followup on the VIN path unchanged", async () => {
+		const user = userEvent.setup();
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		vi.stubGlobal("navigator", {
+			...navigator,
+			clipboard: { writeText },
+		});
+
+		useAppStore.setState({
+			notifications: [
+				createReminderNotification({
+					id: "follow-1",
+					type: "booking_followup",
+					title: "Booking Follow-up",
+					path: "/booking",
+					tabName: "Booking",
+					bookingDate: "2026-03-01",
+				}),
+			],
+		});
+
+		render(<NotificationsDropdown />);
+		await user.click(screen.getByTitle("Notifications"));
+		await user.click(screen.getByText("Booking Follow-up"));
+
+		expect(routerPush).toHaveBeenCalledWith("/booking");
+		expect(writeText).toHaveBeenCalledWith("VIN1");
+		expect(useAppStore.getState().highlightedRowId).toBeNull();
+	});
+});

--- a/src/test/notificationSlice.test.ts
+++ b/src/test/notificationSlice.test.ts
@@ -189,6 +189,26 @@ describe("notificationSlice", () => {
 			expect(notifications[0].path).toBe("/call-list");
 		});
 
+		it("routes archive-stage reminders to /archive (not /orders fallback)", () => {
+			const now = new Date("2026-03-01T12:00:00Z");
+			vi.setSystemTime(now);
+
+			const row = createMockRow("arch-1", undefined, "archive");
+			row.reminder = {
+				date: "2026-03-01",
+				time: "09:00",
+				subject: "Archive follow-up",
+			};
+
+			const store = createTestStore([row]);
+			store.getState().checkNotifications();
+
+			const notifications = store.getState().notifications;
+			expect(notifications).toHaveLength(1);
+			expect(notifications[0].tabName).toBe("Archive");
+			expect(notifications[0].path).toBe("/archive");
+		});
+
 		it("preserves dismissed keys and resurfaces the item once the candidate cache is refetched after eviction", () => {
 			const now = new Date("2026-03-01T12:00:00Z");
 			vi.setSystemTime(now);

--- a/src/test/orderStage.test.ts
+++ b/src/test/orderStage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeOrderStage } from "@/lib/orderStage";
+import { normalizeOrderStage, ORDER_STAGE_TAB_INFO } from "@/lib/orderStage";
 
 describe("normalizeOrderStage", () => {
 	it("maps display labels to canonical stages", () => {
@@ -21,5 +21,18 @@ describe("normalizeOrderStage", () => {
 		expect(normalizeOrderStage("Unknown Stage")).toBeUndefined();
 		expect(normalizeOrderStage(null)).toBeUndefined();
 		expect(normalizeOrderStage(undefined)).toBeUndefined();
+	});
+});
+
+describe("ORDER_STAGE_TAB_INFO", () => {
+	it("covers all five stages including archive", () => {
+		expect(ORDER_STAGE_TAB_INFO.orders.path).toBe("/orders");
+		expect(ORDER_STAGE_TAB_INFO.main.path).toBe("/main-sheet");
+		expect(ORDER_STAGE_TAB_INFO.call.path).toBe("/call-list");
+		expect(ORDER_STAGE_TAB_INFO.booking.path).toBe("/booking");
+		expect(ORDER_STAGE_TAB_INFO.archive).toEqual({
+			name: "Archive",
+			path: "/archive",
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Notification clicks previously navigated using a stale creation-time `path`/`tabName`, so after Temp Mode or saved moves (e.g. Main Sheet → Call List) the wrong tab opened.
- Resolve the row's live stage at click time via `getWorkingRows`, navigate to that route, and use a stage-scoped highlight request so only the matching DataGrid consumes the jump.
- If the row is missing from every stage, toast and skip navigation instead of jumping to a stale path. Archive stage now maps to `/archive` via a shared five-stage route map.

## Root causes addressed
1. Notifications stamped `path` from server-persisted candidates (draft moves invisible).
2. `processDueItems` reused existing notification objects when `managedKey` matched (keys omit stage → stale path after save).
3. Bare global `highlightedRowId` could be consumed/cleared by any mounted grid.
4. `STAGE_TAB_INFO` lacked `archive` → fell back to `/orders`.

## Test plan
- [x] Click with draft move main→call navigates to `/call-list`
- [x] Saved move while notification still has `/main-sheet` navigates to `/call-list`
- [x] Missing row: toast, no navigation
- [x] DataGrid ignores jump request for another stage
- [x] Archive-stage reminder routes to `/archive`
- [x] `npm run test` (691 passed)
- [x] `npm run type-check`
- [x] Biome clean on changed files
