### PR TITLE
fix(notifications): refresh routing metadata on stage moves and resolve live stage navigation

### DIFF
--- a/src/components/shared/NotificationsDropdown.tsx
+++ b/src/components/shared/NotificationsDropdown.tsx
@@ -23,9 +23,18 @@ export function resolveNotificationStage(
 	// A draft overlay coerces unloaded stages to [] (see _captureBaseline), so
 	// during an active draft an unloaded stage is indistinguishable from empty.
 	// Treat that as incomplete coverage so the path fallback stays available.
-	let hasIncompleteCoverage =
+	const hasActiveDraft =
 		state.draftSession.isActive &&
 		state.draftSession.pendingCommands.length > 0;
+	const existedInDraftBaseline =
+		hasActiveDraft &&
+		ORDER_STAGES.some((stage) =>
+			state.draftSession.baselineByStage[stage].some(
+				(row) => row.id === referenceId,
+			),
+		);
+
+	let hasIncompleteCoverage = hasActiveDraft;
 
 	for (const stage of ORDER_STAGES) {
 		const rows = getWorkingRows(stage);
@@ -36,6 +45,11 @@ export function resolveNotificationStage(
 		if (rows.some((row) => row.id === referenceId)) {
 			return stage;
 		}
+	}
+
+	// Baseline row absent from every working stage was removed by the draft overlay.
+	if (existedInDraftBaseline) {
+		return undefined;
 	}
 
 	if (!hasIncompleteCoverage || !notificationPath) {

--- a/src/components/shared/NotificationsDropdown.tsx
+++ b/src/components/shared/NotificationsDropdown.tsx
@@ -15,15 +15,36 @@ import type { AppNotification } from "@/types";
 /** Resolve which stage currently holds the order (draft overlay or persisted cache). */
 export function resolveNotificationStage(
 	referenceId: string,
+	notificationPath?: string,
 ): OrderStage | undefined {
-	const getWorkingRows = useAppStore.getState().getWorkingRows;
+	const state = useAppStore.getState();
+	const getWorkingRows = state.getWorkingRows;
+
+	// A draft overlay coerces unloaded stages to [] (see _captureBaseline), so
+	// during an active draft an unloaded stage is indistinguishable from empty.
+	// Treat that as incomplete coverage so the path fallback stays available.
+	let hasIncompleteCoverage =
+		state.draftSession.isActive &&
+		state.draftSession.pendingCommands.length > 0;
+
 	for (const stage of ORDER_STAGES) {
 		const rows = getWorkingRows(stage);
-		if (rows?.some((row) => row.id === referenceId)) {
+		if (rows === undefined) {
+			hasIncompleteCoverage = true;
+			continue;
+		}
+		if (rows.some((row) => row.id === referenceId)) {
 			return stage;
 		}
 	}
-	return undefined;
+
+	if (!hasIncompleteCoverage || !notificationPath) {
+		return undefined;
+	}
+
+	return ORDER_STAGES.find(
+		(stage) => ORDER_STAGE_TAB_INFO[stage].path === notificationPath,
+	);
 }
 
 export const NotificationsDropdown = () => {
@@ -54,7 +75,7 @@ export const NotificationsDropdown = () => {
 			return;
 		}
 
-		const resolvedStage = resolveNotificationStage(n.referenceId);
+		const resolvedStage = resolveNotificationStage(n.referenceId, n.path);
 		if (!resolvedStage) {
 			toast.error("Order no longer available");
 			setShowNotifications(false);

--- a/src/store/slices/notificationSlice.ts
+++ b/src/store/slices/notificationSlice.ts
@@ -283,7 +283,17 @@ export const createNotificationSlice: StateCreator<
 					);
 
 					if (existing) {
-						newNotifications.push(existing);
+						if (
+							existing.path !== due.path ||
+							existing.tabName !== due.tabName
+						) {
+							hasChanges = true;
+						}
+						newNotifications.push({
+							...existing,
+							path: due.path,
+							tabName: due.tabName,
+						});
 					} else {
 						// New due item found (or updated subject causing a different key)
 						newNotifications.push({

--- a/src/test/NotificationsDropdown.test.tsx
+++ b/src/test/NotificationsDropdown.test.tsx
@@ -188,6 +188,29 @@ describe("resolveNotificationStage", () => {
 		expect(resolveNotificationStage("row-1", "/booking")).toBe("booking");
 	});
 
+	it("does not fall back to path for a baseline row removed by the active draft", () => {
+		const row = createRow("row-1", "main");
+		useAppStore.setState({
+			draftSession: {
+				...useAppStore.getState().draftSession,
+				isActive: true,
+				pendingCommands: [
+					{ type: "deleteRows", ids: ["row-1"] } satisfies DraftCommand,
+				],
+				baselineByStage: {
+					orders: [],
+					main: [row],
+					call: [],
+					booking: [],
+					archive: [],
+				},
+			},
+		});
+		stubAllStagesEmpty();
+
+		expect(resolveNotificationStage("row-1", "/main-sheet")).toBeUndefined();
+	});
+
 	it("returns undefined for an unknown path when coverage is incomplete", () => {
 		stubWorkingRows({});
 		expect(resolveNotificationStage("row-1", "/unknown")).toBeUndefined();
@@ -316,6 +339,33 @@ describe("NotificationsDropdown click-time navigation", () => {
 		await openAndClickNotification();
 
 		expect(routerPush).not.toHaveBeenCalled();
+		expect(toastError).toHaveBeenCalledWith("Order no longer available");
+	});
+
+	it("skips navigation when a baseline row was removed by the active draft", async () => {
+		const row = createRow("row-1", "main");
+		useAppStore.setState({
+			draftSession: {
+				...useAppStore.getState().draftSession,
+				isActive: true,
+				pendingCommands: [
+					{ type: "deleteRows", ids: ["row-1"] } satisfies DraftCommand,
+				],
+				baselineByStage: {
+					orders: [],
+					main: [row],
+					call: [],
+					booking: [],
+					archive: [],
+				},
+			},
+		});
+		stubAllStagesEmpty();
+
+		await openAndClickNotification();
+
+		expect(routerPush).not.toHaveBeenCalled();
+		expect(useAppStore.getState().highlightedRowId).toBeNull();
 		expect(toastError).toHaveBeenCalledWith("Order no longer available");
 	});
 

--- a/src/test/NotificationsDropdown.test.tsx
+++ b/src/test/NotificationsDropdown.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OrderStage } from "@/domain/order/orderStage";
+import { ORDER_STAGE_TAB_INFO } from "@/lib/orderStage";
+import type { DraftCommand } from "@/store/slices/draftSessionCommands";
 import { useAppStore } from "@/store/useStore";
 import type { AppNotification, PendingRow } from "@/types";
 
@@ -34,6 +36,14 @@ import {
 	NotificationsDropdown,
 	resolveNotificationStage,
 } from "@/components/shared/NotificationsDropdown";
+
+const ALL_STAGES: OrderStage[] = [
+	"orders",
+	"main",
+	"call",
+	"booking",
+	"archive",
+];
 
 const createRow = (id: string, stage: OrderStage): PendingRow =>
 	({
@@ -79,14 +89,38 @@ const createReminderNotification = (
 	...overrides,
 });
 
-function stubWorkingRows(byStage: Partial<Record<OrderStage, PendingRow[]>>) {
+function stubWorkingRows(
+	byStage: Partial<Record<OrderStage, PendingRow[] | undefined>>,
+) {
 	useAppStore.setState({
-		getWorkingRows: (stage: OrderStage) => byStage[stage] ?? [],
+		getWorkingRows: (stage: OrderStage) => byStage[stage],
+	});
+}
+
+function stubAllStagesEmpty() {
+	stubWorkingRows({
+		orders: [],
+		main: [],
+		call: [],
+		booking: [],
+		archive: [],
+	});
+}
+
+function resetDraftSessionInactive() {
+	const current = useAppStore.getState().draftSession;
+	useAppStore.setState({
+		draftSession: {
+			...current,
+			isActive: false,
+			pendingCommands: [],
+		},
 	});
 }
 
 describe("resolveNotificationStage", () => {
 	beforeEach(() => {
+		resetDraftSessionInactive();
 		stubWorkingRows({});
 	});
 
@@ -112,12 +146,64 @@ describe("resolveNotificationStage", () => {
 		});
 		expect(resolveNotificationStage("row-1")).toBeUndefined();
 	});
+
+	it("prefers a loaded call cache over a stale /main-sheet path", () => {
+		stubWorkingRows({
+			call: [createRow("row-1", "call")],
+		});
+		expect(resolveNotificationStage("row-1", "/main-sheet")).toBe("call");
+	});
+
+	it("prefers an unsaved draft move in working rows over the notification path", () => {
+		stubWorkingRows({
+			main: [],
+			call: [createRow("row-1", "call")],
+		});
+		expect(resolveNotificationStage("row-1", "/main-sheet")).toBe("call");
+	});
+
+	it("falls back to each canonical path when all stage caches are unloaded", () => {
+		stubWorkingRows({});
+		for (const stage of ALL_STAGES) {
+			expect(
+				resolveNotificationStage("row-1", ORDER_STAGE_TAB_INFO[stage].path),
+			).toBe(stage);
+		}
+	});
+
+	it("returns undefined when all caches are loaded, row is absent, and draft is inactive", () => {
+		stubAllStagesEmpty();
+		expect(resolveNotificationStage("row-1", "/main-sheet")).toBeUndefined();
+	});
+
+	it("falls back to path during an active draft even when every stage returns an array", () => {
+		useAppStore.setState({
+			draftSession: {
+				...useAppStore.getState().draftSession,
+				isActive: true,
+				pendingCommands: [{} as DraftCommand],
+			},
+		});
+		stubAllStagesEmpty();
+		expect(resolveNotificationStage("row-1", "/booking")).toBe("booking");
+	});
+
+	it("returns undefined for an unknown path when coverage is incomplete", () => {
+		stubWorkingRows({});
+		expect(resolveNotificationStage("row-1", "/unknown")).toBeUndefined();
+	});
+
+	it("returns undefined when coverage is incomplete and no path is provided", () => {
+		stubWorkingRows({});
+		expect(resolveNotificationStage("row-1")).toBeUndefined();
+	});
 });
 
 describe("NotificationsDropdown click-time navigation", () => {
 	beforeEach(() => {
 		routerPush.mockReset();
 		toastError.mockReset();
+		resetDraftSessionInactive();
 		useAppStore.setState({
 			notifications: [createReminderNotification()],
 			highlightedRowId: null,
@@ -176,12 +262,60 @@ describe("NotificationsDropdown click-time navigation", () => {
 	});
 
 	it("skips navigation and toasts when the row is not in any stage", async () => {
-		stubWorkingRows({});
+		stubAllStagesEmpty();
 
 		await openAndClickNotification();
 
 		expect(routerPush).not.toHaveBeenCalled();
 		expect(useAppStore.getState().highlightedRowId).toBeNull();
+		expect(toastError).toHaveBeenCalledWith("Order no longer available");
+	});
+
+	it("navigates via path fallback when all stage caches are unloaded (Dashboard)", async () => {
+		useAppStore.setState({
+			notifications: [
+				createReminderNotification({
+					path: "/booking",
+					tabName: "Booking",
+				}),
+			],
+		});
+		stubWorkingRows({});
+
+		await openAndClickNotification();
+
+		expect(routerPush).toHaveBeenCalledWith("/booking");
+		expect(useAppStore.getState().highlightedRowId).toEqual({
+			stage: "booking",
+			id: "row-1",
+		});
+		expect(toastError).not.toHaveBeenCalled();
+	});
+
+	it("navigates to live call stage over a stale /main-sheet notification path", async () => {
+		useAppStore.setState({
+			notifications: [
+				createReminderNotification({
+					path: "/main-sheet",
+					tabName: "Main Sheet",
+				}),
+			],
+		});
+		stubWorkingRows({
+			call: [createRow("row-1", "call")],
+		});
+
+		await openAndClickNotification();
+
+		expect(routerPush).toHaveBeenCalledWith("/call-list");
+	});
+
+	it("toasts when all caches are loaded empty even with a valid path", async () => {
+		stubAllStagesEmpty();
+
+		await openAndClickNotification();
+
+		expect(routerPush).not.toHaveBeenCalled();
 		expect(toastError).toHaveBeenCalledWith("Order no longer available");
 	});
 

--- a/src/test/notificationSlice.test.ts
+++ b/src/test/notificationSlice.test.ts
@@ -164,6 +164,39 @@ describe("notificationSlice", () => {
 		expect(store.getState().notifications).toHaveLength(0);
 	});
 
+	describe("Routing metadata refresh on existing managed notifications", () => {
+		it("refreshes path and tabName when the same managed key moves stage, preserving identity fields", () => {
+			const now = new Date("2026-03-01T12:00:00Z");
+			vi.setSystemTime(now);
+
+			const row = createMockRow("1", undefined, "main");
+			row.reminder = {
+				date: "2026-03-01",
+				time: "10:00",
+				subject: "Follow up",
+			};
+
+			const store = createTestStore([row]);
+			store.getState().checkNotifications();
+
+			const original = store.getState().notifications[0];
+			expect(original.path).toBe("/main-sheet");
+			expect(original.tabName).toBe("Main Sheet");
+
+			const movedRow = { ...row, stage: "call" as OrderStage };
+			queryClient.setQueryData(NOTIFICATION_CANDIDATES_QUERY_KEY, [movedRow]);
+			store.getState().checkNotifications();
+
+			const updated = store.getState().notifications[0];
+			expect(updated.path).toBe("/call-list");
+			expect(updated.tabName).toBe("Call List");
+			expect(updated.id).toBe(original.id);
+			expect(updated.timestamp).toBe(original.timestamp);
+			expect(updated.isRead).toBe(original.isRead);
+			expect(updated.description).toBe(original.description);
+		});
+	});
+
 	describe("Server-authoritative candidate source (MAH-39)", () => {
 		it("surfaces a reminder from a stage whose page has never been opened in this session", () => {
 			const now = new Date("2026-03-01T12:00:00Z");


### PR DESCRIPTION
## Description

- Updates 
otificationSlice to refresh path and 	abName metadata on existing notifications when an order moves stage.
- Enhances NotificationsDropdown to resolve live stage navigation correctly and prevent jumping to stale paths.
- Adds comprehensive unit tests in 
otificationSlice.test.ts and NotificationsDropdown.test.tsx.

## Verification
- 
pm run type-check: 0 errors
- 
pm run lint: Passed
- 
pm run test: Passed 43/43 tests in modified files