### PR TITLE
refactor(booking): extract ReorderReasonDialog (#176) + BookingToolbar (#177)

### DIFF
--- a/src/app/(app)/booking/page.tsx
+++ b/src/app/(app)/booking/page.tsx
@@ -1,68 +1,31 @@
 "use client";
 
 import type { GridApi } from "ag-grid-community";
-import {
-	Archive,
-	Calendar,
-	CheckCircle,
-	Download,
-	Filter,
-	RotateCcw,
-	Tag,
-	Trash2,
-} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { BookingToolbar } from "@/components/booking/BookingToolbar";
 import { DynamicDataGrid as DataGrid } from "@/components/grid";
 import { BookingCalendarModal } from "@/components/shared/BookingCalendarModal";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { getBookingColumns } from "@/components/shared/GridConfig";
 import { InfoLabel } from "@/components/shared/InfoLabel";
-import { LayoutSaveButton } from "@/components/shared/LayoutSaveButton";
+import { ReorderReasonDialog } from "@/components/shared/ReorderReasonDialog";
 import { RowModals } from "@/components/shared/RowModals";
-import { SelectAllByVinButton } from "@/components/shared/SelectAllByVinButton";
-import { VINLineCounter } from "@/components/shared/VINLineCounter";
-import { Button } from "@/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import {
 	filterReservedRows,
 	hasMixedVinSelection,
 } from "@/domain/order/orderWorkflow";
 import { useOrdersQuery } from "@/hooks/queries/useOrdersQuery";
-import { useColumnLayoutTracker } from "@/hooks/useColumnLayoutTracker";
 import { useDraftSession } from "@/hooks/useDraftSession";
 import { useRowModals } from "@/hooks/useRowModals";
 import { useSelectAllByVin } from "@/hooks/useSelectAllByVin";
 import { useSelectedRowsSync } from "@/hooks/useSelectedRowsSync";
 import { trySelectRowsByVin } from "@/lib/ag-grid-helpers";
 import { printReservationLabels } from "@/lib/printing/reservationLabels";
-import { cn } from "@/lib/utils";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
 import { useBookingPageActions } from "./useBookingPageActions";
 
 export default function BookingPage() {
-	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
-		useColumnLayoutTracker("booking");
 	const { data: bookingRowData = [] } = useOrdersQuery("booking");
 
 	// Draft session for undo/redo
@@ -176,200 +139,34 @@ export default function BookingPage() {
 		<div className="space-y-4 h-full flex flex-col">
 			<InfoLabel data={selectedRows[0] || null} />
 
-			<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
-				<div className="flex items-center gap-1.5">
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
-								onClick={() => gridApi?.exportDataAsCsv()}
-							>
-								<Download className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Extract</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-gray-400 hover:text-white h-8 w-8"
-								onClick={() => setShowFilters(!showFilters)}
-							>
-								<Filter className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Filter</TooltipContent>
-					</Tooltip>
-
-					<LayoutSaveButton
-						isDirty={isDirty}
-						isPositionDirty={isPositionDirty}
-						onSave={saveLayout}
-						onSaveAsDefault={saveAsDefault}
-						onReset={resetLayout}
-					/>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-gray-400 hover:text-white h-8 w-8"
-								onClick={() => {
-									const reservedRows = filterReservedRows(
-										selectedRows,
-										partStatuses,
-									);
-									if (reservedRows.length === 0) return;
-									printReservationLabels(reservedRows);
-								}}
-								disabled={selectedRows.length === 0}
-							>
-								<Tag className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Reserve/Print Label</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon"
-										className="text-gray-400 hover:text-white h-8 w-8"
-										disabled={selectedRows.length === 0}
-									>
-										<CheckCircle className="h-4 w-4" />
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent
-									align="end"
-									className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
-								>
-									{partStatuses?.map((status) => {
-										const isHex =
-											status.color?.startsWith("#") ||
-											status.color?.startsWith("rgb");
-										const dotStyle = isHex
-											? { backgroundColor: status.color }
-											: undefined;
-										const colorClass = isHex ? "" : status.color;
-
-										return (
-											<DropdownMenuItem
-												key={status.id}
-												onClick={() => handleUpdatePartStatus(status.label)}
-												className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
-											>
-												<div
-													className={cn("w-2 h-2 rounded-full", colorClass)}
-													style={dotStyle}
-												/>
-												<span className="text-xs">{status.label}</span>
-											</DropdownMenuItem>
-										);
-									})}
-								</DropdownMenuContent>
-							</DropdownMenu>
-						</TooltipTrigger>
-						<TooltipContent>Update Status</TooltipContent>
-					</Tooltip>
-
-					<div className="w-px h-5 bg-white/10 mx-1" />
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-gray-400 hover:text-white h-8 w-8"
-								onClick={() => {
-									if (selectedRows.length > 0) {
-										handleArchiveClick(
-											selectedRows[0],
-											selectedRows.map((r) => r.id),
-										);
-									}
-								}}
-								disabled={selectedRows.length === 0 || hasMixedVins}
-							>
-								<Archive className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{hasMixedVins ? "Mixed customers selected" : "Archive"}
-						</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-green-500/80 hover:text-green-500 h-8 w-8"
-								onClick={() => setIsRebookingModalOpen(true)}
-								disabled={
-									selectedRows.length === 0 || draftDirty || hasMixedVins
-								}
-							>
-								<Calendar className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{hasMixedVins
-								? "Mixed customers selected"
-								: draftDirty
-									? "Save draft first"
-									: "Reschedule Booking"}
-						</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
-								onClick={() => setIsReorderModalOpen(true)}
-								disabled={selectedRows.length === 0 || hasMixedVins}
-							>
-								<RotateCcw className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{hasMixedVins ? "Mixed customers selected" : "Reorder"}
-						</TooltipContent>
-					</Tooltip>
-				</div>
-
-				<div className="flex items-center gap-1.5">
-					<SelectAllByVinButton
-						onSelectAllByVin={onSelectAllByVin}
-						isDisabled={isSelectAllByVinDisabled}
-					/>
-					<VINLineCounter rows={effectiveBookingData} />
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
-								onClick={() => setShowDeleteConfirm(true)}
-								disabled={selectedRows.length === 0}
-							>
-								<Trash2 className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Delete</TooltipContent>
-					</Tooltip>
-				</div>
-			</div>
+			<BookingToolbar
+				selectedRows={selectedRows}
+				partStatuses={partStatuses}
+				rowData={effectiveBookingData}
+				draftDirty={draftDirty}
+				hasMixedVins={hasMixedVins}
+				onExtract={() => gridApi?.exportDataAsCsv()}
+				onFilterToggle={() => setShowFilters((v) => !v)}
+				onReserve={() => {
+					const reservedRows = filterReservedRows(selectedRows, partStatuses);
+					if (reservedRows.length === 0) return;
+					printReservationLabels(reservedRows);
+				}}
+				onUpdateStatus={handleUpdatePartStatus}
+				onArchive={() => {
+					if (selectedRows.length > 0) {
+						handleArchiveClick(
+							selectedRows[0],
+							selectedRows.map((r) => r.id),
+						);
+					}
+				}}
+				onRebook={() => setIsRebookingModalOpen(true)}
+				onReorder={() => setIsReorderModalOpen(true)}
+				onDelete={() => setShowDeleteConfirm(true)}
+				onSelectAllByVin={onSelectAllByVin}
+				isSelectAllByVinDisabled={isSelectAllByVinDisabled}
+			/>
 
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
 			<div
@@ -417,53 +214,22 @@ export default function BookingPage() {
 				/>
 			</div>
 
-			<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
-				<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
-					<DialogHeader>
-						<DialogTitle className="text-orange-500">
-							Reorder - Reason Required
-						</DialogTitle>
-						<DialogDescription className="sr-only">
-							Provide a reason why this order is being sent back for reordering.
-						</DialogDescription>
-					</DialogHeader>
-					<div className="space-y-4">
-						<div>
-							<Label>Reason for Reorder</Label>
-							<Input
-								value={reorderReason}
-								onChange={(e) => setReorderReason(e.target.value)}
-								placeholder="e.g., Wrong part, Customer cancelled"
-								className="bg-white/5 border-white/10 text-white"
-							/>
-						</div>
-						<p className="text-sm text-muted-foreground">
-							This will send the selected items back to the Orders view.
-						</p>
-					</div>
-					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setIsReorderModalOpen(false)}
-							className="border-white/20 text-white hover:bg-white/10"
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="renault"
-							onClick={() =>
-								handleConfirmReorder(reorderReason, () => {
-									setIsReorderModalOpen(false);
-									setReorderReason("");
-								})
-							}
-							disabled={!reorderReason.trim()}
-						>
-							Confirm Reorder
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<ReorderReasonDialog
+				open={isReorderModalOpen}
+				onOpenChange={setIsReorderModalOpen}
+				reason={reorderReason}
+				onReasonChange={setReorderReason}
+				onCancel={() => setIsReorderModalOpen(false)}
+				onConfirm={() =>
+					handleConfirmReorder(reorderReason, () => {
+						setIsReorderModalOpen(false);
+						setReorderReason("");
+					})
+				}
+				placeholder="e.g., Wrong part, Customer cancelled"
+				helperText="This will send the selected items back to the Orders view."
+				srDescription="Provide a reason why this order is being sent back for reordering."
+			/>
 
 			<BookingCalendarModal
 				open={isRebookingModalOpen}

--- a/src/components/booking/BookingToolbar.tsx
+++ b/src/components/booking/BookingToolbar.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import {
+	Archive,
+	Calendar,
+	CheckCircle,
+	Download,
+	Filter,
+	RotateCcw,
+	Tag,
+	Trash2,
+} from "lucide-react";
+import { LayoutSaveButton } from "@/components/shared/LayoutSaveButton";
+import { SelectAllByVinButton } from "@/components/shared/SelectAllByVinButton";
+import { VINLineCounter } from "@/components/shared/VINLineCounter";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useColumnLayoutTracker } from "@/hooks/useColumnLayoutTracker";
+import { cn } from "@/lib/utils";
+import type { PartStatusDef, PendingRow } from "@/types";
+
+interface BookingToolbarProps {
+	selectedRows: PendingRow[];
+	partStatuses?: PartStatusDef[];
+	rowData?: PendingRow[];
+	draftDirty: boolean;
+	hasMixedVins: boolean;
+	onExtract: () => void;
+	onFilterToggle: () => void;
+	onReserve: () => void;
+	onUpdateStatus: (statusLabel: string) => void;
+	onArchive: () => void;
+	onRebook: () => void;
+	onReorder: () => void;
+	onDelete: () => void;
+	onSelectAllByVin: () => void;
+	isSelectAllByVinDisabled: boolean;
+}
+
+export const BookingToolbar = ({
+	selectedRows = [],
+	partStatuses = [],
+	rowData = [],
+	draftDirty,
+	hasMixedVins,
+	onExtract,
+	onFilterToggle,
+	onReserve,
+	onUpdateStatus,
+	onArchive,
+	onRebook,
+	onReorder,
+	onDelete,
+	onSelectAllByVin,
+	isSelectAllByVinDisabled,
+}: BookingToolbarProps) => {
+	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
+		useColumnLayoutTracker("booking");
+
+	return (
+		<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
+			<div className="flex items-center gap-1.5">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
+							onClick={onExtract}
+						>
+							<Download className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Extract</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-gray-400 hover:text-white h-8 w-8"
+							onClick={onFilterToggle}
+						>
+							<Filter className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Filter</TooltipContent>
+				</Tooltip>
+
+				<LayoutSaveButton
+					isDirty={isDirty}
+					isPositionDirty={isPositionDirty}
+					onSave={saveLayout}
+					onSaveAsDefault={saveAsDefault}
+					onReset={resetLayout}
+				/>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-gray-400 hover:text-white h-8 w-8"
+							onClick={onReserve}
+							disabled={selectedRows.length === 0}
+						>
+							<Tag className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Reserve/Print Label</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="text-gray-400 hover:text-white h-8 w-8"
+									disabled={selectedRows.length === 0}
+								>
+									<CheckCircle className="h-4 w-4" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								align="end"
+								className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
+							>
+								{partStatuses?.map((status) => {
+									const isHex =
+										status.color?.startsWith("#") ||
+										status.color?.startsWith("rgb");
+									const dotStyle = isHex
+										? { backgroundColor: status.color }
+										: undefined;
+									const colorClass = isHex ? "" : status.color;
+
+									return (
+										<DropdownMenuItem
+											key={status.id}
+											onClick={() => onUpdateStatus(status.label)}
+											className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
+										>
+											<div
+												className={cn("w-2 h-2 rounded-full", colorClass)}
+												style={dotStyle}
+											/>
+											<span className="text-xs">{status.label}</span>
+										</DropdownMenuItem>
+									);
+								})}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</TooltipTrigger>
+					<TooltipContent>Update Status</TooltipContent>
+				</Tooltip>
+
+				<div className="w-px h-5 bg-white/10 mx-1" />
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-gray-400 hover:text-white h-8 w-8"
+							onClick={onArchive}
+							disabled={selectedRows.length === 0 || hasMixedVins}
+						>
+							<Archive className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{hasMixedVins ? "Mixed customers selected" : "Archive"}
+					</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-green-500/80 hover:text-green-500 h-8 w-8"
+							onClick={onRebook}
+							disabled={selectedRows.length === 0 || draftDirty || hasMixedVins}
+						>
+							<Calendar className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{hasMixedVins
+							? "Mixed customers selected"
+							: draftDirty
+								? "Save draft first"
+								: "Reschedule Booking"}
+					</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
+							onClick={onReorder}
+							disabled={selectedRows.length === 0 || hasMixedVins}
+						>
+							<RotateCcw className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{hasMixedVins ? "Mixed customers selected" : "Reorder"}
+					</TooltipContent>
+				</Tooltip>
+			</div>
+
+			<div className="flex items-center gap-1.5">
+				<SelectAllByVinButton
+					onSelectAllByVin={onSelectAllByVin}
+					isDisabled={isSelectAllByVinDisabled}
+				/>
+				<VINLineCounter rows={rowData} />
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
+							onClick={onDelete}
+							disabled={selectedRows.length === 0}
+						>
+							<Trash2 className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Delete</TooltipContent>
+				</Tooltip>
+			</div>
+		</div>
+	);
+};

--- a/src/components/shared/ReorderReasonDialog.tsx
+++ b/src/components/shared/ReorderReasonDialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export interface ReorderReasonDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	reason: string;
+	onReasonChange: (value: string) => void;
+	onCancel: () => void;
+	onConfirm: () => void;
+	placeholder: string;
+	helperText?: string;
+	srDescription?: string;
+}
+
+export function ReorderReasonDialog({
+	open,
+	onOpenChange,
+	reason,
+	onReasonChange,
+	onCancel,
+	onConfirm,
+	placeholder,
+	helperText,
+	srDescription,
+}: ReorderReasonDialogProps) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
+				<DialogHeader>
+					<DialogTitle className="text-orange-500">
+						Reorder - Reason Required
+					</DialogTitle>
+					{srDescription ? (
+						<DialogDescription className="sr-only">
+							{srDescription}
+						</DialogDescription>
+					) : null}
+				</DialogHeader>
+				<div className="space-y-4">
+					<div>
+						<Label>Reason for Reorder</Label>
+						<Input
+							value={reason}
+							onChange={(e) => onReasonChange(e.target.value)}
+							placeholder={placeholder}
+							className="bg-white/5 border-white/10 text-white"
+						/>
+					</div>
+					{helperText ? (
+						<p className="text-sm text-muted-foreground">{helperText}</p>
+					) : null}
+				</div>
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={onCancel}
+						className="border-white/20 text-white hover:bg-white/10"
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="renault"
+						onClick={onConfirm}
+						disabled={!reason.trim()}
+					>
+						Confirm Reorder
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/test/BookingToolbar.test.tsx
+++ b/src/test/BookingToolbar.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BookingToolbar } from "@/components/booking/BookingToolbar";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { PendingRow } from "@/types";
+
+const renderWithProvider = (ui: React.ReactElement) => {
+	return render(<TooltipProvider>{ui}</TooltipProvider>);
+};
+
+const mockSelectedRows: PendingRow[] = [
+	{
+		id: "1",
+		vin: "VIN123",
+		customerName: "Customer 1",
+	} as PendingRow,
+];
+
+const defaultProps = {
+	selectedRows: mockSelectedRows,
+	partStatuses: [],
+	rowData: mockSelectedRows,
+	draftDirty: false,
+	hasMixedVins: false,
+	onExtract: vi.fn(),
+	onFilterToggle: vi.fn(),
+	onReserve: vi.fn(),
+	onUpdateStatus: vi.fn(),
+	onArchive: vi.fn(),
+	onRebook: vi.fn(),
+	onReorder: vi.fn(),
+	onDelete: vi.fn(),
+	onSelectAllByVin: vi.fn(),
+	isSelectAllByVinDisabled: false,
+};
+
+describe("BookingToolbar", () => {
+	it("disables the Reschedule Booking button when draftDirty is true (with a selection)", () => {
+		const { container } = renderWithProvider(
+			<BookingToolbar
+				{...defaultProps}
+				selectedRows={mockSelectedRows}
+				draftDirty={true}
+			/>,
+		);
+		const rescheduleButton = container
+			.querySelector(".lucide-calendar")
+			?.closest("button");
+		expect(rescheduleButton).toBeDisabled();
+	});
+
+	it("disables Archive, Reschedule, and Reorder buttons when hasMixedVins is true", () => {
+		const { container } = renderWithProvider(
+			<BookingToolbar
+				{...defaultProps}
+				selectedRows={mockSelectedRows}
+				hasMixedVins={true}
+			/>,
+		);
+		const archiveButton = container
+			.querySelector(".lucide-archive")
+			?.closest("button");
+		const rescheduleButton = container
+			.querySelector(".lucide-calendar")
+			?.closest("button");
+		const reorderButton = container
+			.querySelector(".lucide-rotate-ccw")
+			?.closest("button");
+
+		expect(archiveButton).toBeDisabled();
+		expect(rescheduleButton).toBeDisabled();
+		expect(reorderButton).toBeDisabled();
+	});
+
+	it("disables the Delete button when selectedRows is empty", () => {
+		const { container } = renderWithProvider(
+			<BookingToolbar {...defaultProps} selectedRows={[]} />,
+		);
+		const deleteButton = container
+			.querySelector(".lucide-trash2")
+			?.closest("button");
+		expect(deleteButton).toBeDisabled();
+	});
+
+	it("calls onReorder when clicking the Reorder button with a valid selection", () => {
+		const onReorder = vi.fn();
+		const { container } = renderWithProvider(
+			<BookingToolbar
+				{...defaultProps}
+				selectedRows={mockSelectedRows}
+				hasMixedVins={false}
+				onReorder={onReorder}
+			/>,
+		);
+		const reorderButton = container
+			.querySelector(".lucide-rotate-ccw")
+			?.closest("button");
+		expect(reorderButton).toBeEnabled();
+		if (!reorderButton) {
+			throw new Error("Reorder button not found");
+		}
+		fireEvent.click(reorderButton);
+		expect(onReorder).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/test/ReorderReasonDialog.test.tsx
+++ b/src/test/ReorderReasonDialog.test.tsx
@@ -1,0 +1,157 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+	ReorderReasonDialog,
+	type ReorderReasonDialogProps,
+} from "@/components/shared/ReorderReasonDialog";
+
+vi.mock("@/components/ui/dialog", () => ({
+	Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+		open ? <div data-testid="reorder-dialog">{children}</div> : null,
+	DialogContent: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogHeader: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DialogTitle: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogDescription: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogFooter: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+const defaultProps: ReorderReasonDialogProps = {
+	open: true,
+	onOpenChange: vi.fn(),
+	reason: "",
+	onReasonChange: vi.fn(),
+	onCancel: vi.fn(),
+	onConfirm: vi.fn(),
+	placeholder: "e.g., Wrong part, Customer cancelled",
+};
+
+const renderDialog = (props?: Partial<ReorderReasonDialogProps>) =>
+	render(<ReorderReasonDialog {...defaultProps} {...props} />);
+
+describe("ReorderReasonDialog", () => {
+	it("renders the given placeholder", () => {
+		renderDialog({ placeholder: "Test placeholder text" });
+
+		expect(
+			screen.getByPlaceholderText("Test placeholder text"),
+		).toBeInTheDocument();
+	});
+
+	it("renders helperText when passed and not when omitted", () => {
+		const { rerender } = render(
+			<ReorderReasonDialog
+				{...defaultProps}
+				helperText="This will send the selected items back to the Orders view."
+			/>,
+		);
+
+		expect(
+			screen.getByText(
+				"This will send the selected items back to the Orders view.",
+			),
+		).toBeInTheDocument();
+
+		rerender(<ReorderReasonDialog {...defaultProps} helperText={undefined} />);
+
+		expect(
+			screen.queryByText(
+				"This will send the selected items back to the Orders view.",
+			),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders srDescription text when passed", () => {
+		const { rerender } = render(
+			<ReorderReasonDialog
+				{...defaultProps}
+				srDescription="Provide a reason why this order is being sent back for reordering."
+			/>,
+		);
+
+		expect(
+			screen.getByText(
+				"Provide a reason why this order is being sent back for reordering.",
+			),
+		).toBeInTheDocument();
+
+		rerender(
+			<ReorderReasonDialog {...defaultProps} srDescription={undefined} />,
+		);
+
+		expect(
+			screen.queryByText(
+				"Provide a reason why this order is being sent back for reordering.",
+			),
+		).not.toBeInTheDocument();
+	});
+
+	it('disables "Confirm Reorder" when reason is empty or whitespace and enables when non-whitespace', () => {
+		const { rerender } = render(
+			<ReorderReasonDialog {...defaultProps} reason="" />,
+		);
+
+		const confirmButton = screen.getByRole("button", {
+			name: /confirm reorder/i,
+		});
+		expect(confirmButton).toBeDisabled();
+
+		rerender(<ReorderReasonDialog {...defaultProps} reason="   " />);
+		expect(confirmButton).toBeDisabled();
+
+		rerender(
+			<ReorderReasonDialog {...defaultProps} reason="Customer cancelled" />,
+		);
+		expect(confirmButton).toBeEnabled();
+	});
+
+	it("calls onConfirm when Confirm Reorder is clicked", () => {
+		const onConfirm = vi.fn();
+		renderDialog({
+			reason: "Wrong part ordered",
+			onConfirm,
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /confirm reorder/i }));
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onCancel and does not call onReasonChange when Cancel is clicked", () => {
+		const onCancel = vi.fn();
+		const onReasonChange = vi.fn();
+		renderDialog({
+			reason: "Some reason",
+			onCancel,
+			onReasonChange,
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(onReasonChange).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Q2 Booking pilot, tier 2. Two pure structural extractions from `src/app/(app)/booking/page.tsx` — **no visible or behavioral change**. Closes #176, closes #177 (both were blocked by #175, merged as `47bc754`).

Implemented by two parallel Antigravity (`agy`) runs, one git worktree each; diffs reviewed and integrated by the orchestrator.

### #176 — shared, parameterized reorder-dialog
- New `src/components/shared/ReorderReasonDialog.tsx`: controlled component wrapping the whole `<Dialog>`. Holds no state — `reason` stays owned by the page.
- `placeholder` is a **required** prop; `helperText` and `srDescription` are **optional** — so a later adopting stage never silently inherits Booking's copy (Call List has the helper but no description; Main Sheet has neither + a different placeholder).
- Fixed literals kept inside: title "Reorder - Reason Required" (`text-orange-500`), label "Reason for Reorder", Cancel (`variant="outline"`) / "Confirm Reorder" (`variant="renault"`, `disabled={!reason.trim()}`).
- Cancel / Esc / click-outside do **not** clear the reason — only a successful confirm does, via the page's callback. Unchanged from before.
- Booking adopts it; the other 3 stages are untouched (follow-up ticket).

### #177 — BookingToolbar component
- New `src/components/booking/BookingToolbar.tsx`: presentational toolbar matching the `MainSheetToolbar` / `OrdersToolbar` pattern. JSX, classNames, icons, tooltip strings, and every `disabled` expression moved in verbatim.
- `useColumnLayoutTracker("booking")` now lives inside the toolbar (both sibling toolbars do the same for their stage); nothing else in `page.tsx` consumed its return values.
- Handlers + disabled-state flags (`draftDirty`, `hasMixedVins`, `selectedRows`) as props. `filterReservedRows` / `printReservationLabels` / `handleArchiveClick` bodies stay in `page.tsx` behind handler props.

`booking/page.tsx`: −280 net lines; import list trimmed to the union of both extractions.

## Tests

- `src/test/ReorderReasonDialog.test.tsx` (6): placeholder renders; `helperText` / `srDescription` render only when passed; Confirm disabled on empty/whitespace, enabled on real text; `onConfirm` fires; `onCancel` fires without calling `onReasonChange`.
- `src/test/BookingToolbar.test.tsx` (4): Reschedule disabled under `draftDirty`; Archive/Reschedule/Reorder disabled under `hasMixedVins`; Delete disabled with empty selection; `onReorder` fires.

## Gate results

| Gate | Result |
| --- | --- |
| `type-check` | pass |
| `test` | pass — 75 files / 733 tests (10 new) |
| `build` | compile + typegen + 27/27 static pages pass; local run dies only at the `output: "standalone"` symlink step (Windows `EPERM`) — env-only, CI unaffected |
| `lint` | verified clean on the 5 changed files; a local `core.autocrlf=true` / CRLF condition makes a full-repo `biome check` noisy on every file, CI unaffected |

## Review

- **`/code-review` (two-axis).** Spec: clean, meets every acceptance criterion, no drift, no scope creep. Standards: no hard violations; judgement-call notes — reorder dialog still has 3 un-migrated stage copies (props pay off once those adopt it → follow-up ticket); `BookingToolbar` is a third parallel toolbar (matches the pattern #177 asked for); toolbar tests select via lucide class names.
- **`/debate-review` (`claude` main + `codex` debate).** Ship — 0 P0 / 0 P1 / 0 P2 / 0 contested.

## Follow-up (not in this PR)

- Migrate `archive` / `call-list` / `main-sheet` reorder dialogs onto `ReorderReasonDialog`.
- Optional: shared toolbar primitives (`StatusDropdown`, `ToolbarIconButton`) across the 3 stage toolbars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGyniZFbLBmKKQZxY4t8YS