### PR TITLE
refactor(booking): extract modal-state hook (#178)

### DIFF
--- a/src/app/(app)/booking/page.tsx
+++ b/src/app/(app)/booking/page.tsx
@@ -23,6 +23,7 @@ import { trySelectRowsByVin } from "@/lib/ag-grid-helpers";
 import { printReservationLabels } from "@/lib/printing/reservationLabels";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
+import { useBookingModals } from "./useBookingModals";
 import { useBookingPageActions } from "./useBookingPageActions";
 
 export default function BookingPage() {
@@ -93,10 +94,23 @@ export default function BookingPage() {
 		effectiveBookingData,
 		setPendingVinSelection,
 	]);
-	const [isReorderModalOpen, setIsReorderModalOpen] = useState(false);
-	const [reorderReason, setReorderReason] = useState("");
-	const [isRebookingModalOpen, setIsRebookingModalOpen] = useState(false);
-	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+	const {
+		isReorderModalOpen,
+		setReorderModalOpen,
+		openReorder,
+		closeReorder,
+		reorderReason,
+		setReorderReason,
+		resetReorder,
+		isRebookingModalOpen,
+		setRebookingModalOpen,
+		openRebooking,
+		closeRebooking,
+		showDeleteConfirm,
+		setShowDeleteConfirm,
+		openDeleteConfirm,
+		closeDeleteConfirm,
+	} = useBookingModals();
 	const [showFilters, setShowFilters] = useState(false);
 	const [scrollDir, setScrollDir] = useState<"vertical" | "horizontal">(
 		"vertical",
@@ -161,9 +175,9 @@ export default function BookingPage() {
 						);
 					}
 				}}
-				onRebook={() => setIsRebookingModalOpen(true)}
-				onReorder={() => setIsReorderModalOpen(true)}
-				onDelete={() => setShowDeleteConfirm(true)}
+				onRebook={openRebooking}
+				onReorder={openReorder}
+				onDelete={openDeleteConfirm}
 				onSelectAllByVin={onSelectAllByVin}
 				isSelectAllByVinDisabled={isSelectAllByVinDisabled}
 			/>
@@ -216,16 +230,11 @@ export default function BookingPage() {
 
 			<ReorderReasonDialog
 				open={isReorderModalOpen}
-				onOpenChange={setIsReorderModalOpen}
+				onOpenChange={setReorderModalOpen}
 				reason={reorderReason}
 				onReasonChange={setReorderReason}
-				onCancel={() => setIsReorderModalOpen(false)}
-				onConfirm={() =>
-					handleConfirmReorder(reorderReason, () => {
-						setIsReorderModalOpen(false);
-						setReorderReason("");
-					})
-				}
+				onCancel={closeReorder}
+				onConfirm={() => handleConfirmReorder(reorderReason, resetReorder)}
 				placeholder="e.g., Wrong part, Customer cancelled"
 				helperText="This will send the selected items back to the Orders view."
 				srDescription="Provide a reason why this order is being sent back for reordering."
@@ -233,12 +242,10 @@ export default function BookingPage() {
 
 			<BookingCalendarModal
 				open={isRebookingModalOpen}
-				onOpenChange={setIsRebookingModalOpen}
+				onOpenChange={setRebookingModalOpen}
 				selectedRows={selectedRows}
 				onConfirm={(date, note, status) =>
-					handleConfirmRebooking(date, note, status, () =>
-						setIsRebookingModalOpen(false),
-					)
+					handleConfirmRebooking(date, note, status, closeRebooking)
 				}
 			/>
 
@@ -257,7 +264,7 @@ export default function BookingPage() {
 				open={showDeleteConfirm}
 				onOpenChange={setShowDeleteConfirm}
 				onConfirm={async () => {
-					await handleConfirmDelete(() => setShowDeleteConfirm(false));
+					await handleConfirmDelete(closeDeleteConfirm);
 				}}
 				title="Delete Bookings"
 				description={`Are you sure you want to delete ${selectedRows.length} selected booking(s)?`}

--- a/src/app/(app)/booking/useBookingModals.ts
+++ b/src/app/(app)/booking/useBookingModals.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+export function useBookingModals() {
+	const [isReorderModalOpen, setIsReorderModalOpen] = useState(false);
+	const [reorderReason, setReorderReason] = useState("");
+	const [isRebookingModalOpen, setIsRebookingModalOpen] = useState(false);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+	return {
+		// reorder
+		isReorderModalOpen,
+		setReorderModalOpen: setIsReorderModalOpen,
+		openReorder: () => setIsReorderModalOpen(true),
+		closeReorder: () => setIsReorderModalOpen(false),
+		reorderReason,
+		setReorderReason,
+		resetReorder: () => {
+			setIsReorderModalOpen(false);
+			setReorderReason("");
+		},
+		// rebooking
+		isRebookingModalOpen,
+		setRebookingModalOpen: setIsRebookingModalOpen,
+		openRebooking: () => setIsRebookingModalOpen(true),
+		closeRebooking: () => setIsRebookingModalOpen(false),
+		// delete
+		showDeleteConfirm,
+		setShowDeleteConfirm,
+		openDeleteConfirm: () => setShowDeleteConfirm(true),
+		closeDeleteConfirm: () => setShowDeleteConfirm(false),
+	};
+}

--- a/src/test/useBookingModals.test.ts
+++ b/src/test/useBookingModals.test.ts
@@ -1,0 +1,190 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useBookingModals } from "@/app/(app)/booking/useBookingModals";
+
+describe("useBookingModals", () => {
+	it("initializes with all modals closed and an empty reorderReason", () => {
+		const { result } = renderHook(() => useBookingModals());
+
+		expect(result.current.isReorderModalOpen).toBe(false);
+		expect(result.current.reorderReason).toBe("");
+		expect(result.current.isRebookingModalOpen).toBe(false);
+		expect(result.current.showDeleteConfirm).toBe(false);
+	});
+
+	describe("reorder modal", () => {
+		it("openReorder() opens modal; closeReorder() closes it and leaves reorderReason unchanged", () => {
+			const { result } = renderHook(() => useBookingModals());
+
+			act(() => {
+				result.current.setReorderReason("Wrong part supplied");
+			});
+			expect(result.current.reorderReason).toBe("Wrong part supplied");
+
+			act(() => {
+				result.current.openReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+
+			act(() => {
+				result.current.closeReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("Wrong part supplied");
+		});
+
+		it("resetReorder() closes modal and clears reorderReason to empty string", () => {
+			const { result } = renderHook(() => useBookingModals());
+
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Customer cancelled");
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.reorderReason).toBe("Customer cancelled");
+
+			act(() => {
+				result.current.resetReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("");
+		});
+
+		it("setReorderModalOpen(false) (the onOpenChange path) closes without clearing a set reason", () => {
+			const { result } = renderHook(() => useBookingModals());
+
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Part defective");
+			});
+
+			act(() => {
+				result.current.setReorderModalOpen(false);
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("Part defective");
+
+			act(() => {
+				result.current.setReorderModalOpen(true);
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.reorderReason).toBe("Part defective");
+		});
+	});
+
+	describe("rebooking modal", () => {
+		it("openRebooking() and closeRebooking() toggle isRebookingModalOpen only", () => {
+			const { result } = renderHook(() => useBookingModals());
+
+			act(() => {
+				result.current.openRebooking();
+			});
+			expect(result.current.isRebookingModalOpen).toBe(true);
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+
+			act(() => {
+				result.current.closeRebooking();
+			});
+			expect(result.current.isRebookingModalOpen).toBe(false);
+		});
+
+		it("setRebookingModalOpen() directly controls isRebookingModalOpen for onOpenChange", () => {
+			const { result } = renderHook(() => useBookingModals());
+
+			act(() => {
+				result.current.setRebookingModalOpen(true);
+			});
+			expect(result.current.isRebookingModalOpen).toBe(true);
+
+			act(() => {
+				result.current.setRebookingModalOpen(false);
+			});
+			expect(result.current.isRebookingModalOpen).toBe(false);
+		});
+	});
+
+	describe("delete confirm modal", () => {
+		it("openDeleteConfirm() and closeDeleteConfirm() toggle showDeleteConfirm only", () => {
+			const { result } = renderHook(() => useBookingModals());
+
+			act(() => {
+				result.current.openDeleteConfirm();
+			});
+			expect(result.current.showDeleteConfirm).toBe(true);
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.isRebookingModalOpen).toBe(false);
+
+			act(() => {
+				result.current.closeDeleteConfirm();
+			});
+			expect(result.current.showDeleteConfirm).toBe(false);
+		});
+
+		it("setShowDeleteConfirm() directly controls showDeleteConfirm for onOpenChange", () => {
+			const { result } = renderHook(() => useBookingModals());
+
+			act(() => {
+				result.current.setShowDeleteConfirm(true);
+			});
+			expect(result.current.showDeleteConfirm).toBe(true);
+
+			act(() => {
+				result.current.setShowDeleteConfirm(false);
+			});
+			expect(result.current.showDeleteConfirm).toBe(false);
+		});
+	});
+
+	describe("cross-independence", () => {
+		it("opening one modal does not change the other modals or mutate state unexpectedly", () => {
+			const { result } = renderHook(() => useBookingModals());
+
+			// Open reorder
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Test reason");
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isRebookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+
+			// Open rebooking
+			act(() => {
+				result.current.openRebooking();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isRebookingModalOpen).toBe(true);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Open delete confirm
+			act(() => {
+				result.current.openDeleteConfirm();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isRebookingModalOpen).toBe(true);
+			expect(result.current.showDeleteConfirm).toBe(true);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Close rebooking & delete confirm - reorder remains open with reason intact
+			act(() => {
+				result.current.closeRebooking();
+				result.current.closeDeleteConfirm();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isRebookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Reset reorder clears reason and closes reorder modal
+			act(() => {
+				result.current.resetReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.isRebookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Closes #178 ([Q3] Booking: extract modal-state hook), the final ticket in the Booking pilot queue (parent #174).

Consolidates Booking's four modal state slots into a co-located `useBookingModals` hook so `page.tsx` becomes a pure composition root wiring the handler hook (#175), the shared reorder dialog (#176), the toolbar (#177), and this modal-state hook together.

## Changes

- **New** `src/app/(app)/booking/useBookingModals.ts` — owns `isReorderModalOpen`, `reorderReason`, `isRebookingModalOpen`, `showDeleteConfirm`; exposes raw setters (for Radix `onOpenChange`), `open*`/`close*` actions, and `resetReorder` (the success path that closes **and** clears the reason).
- `src/app/(app)/booking/page.tsx` — four `useState` lines replaced with one `useBookingModals()` destructure; `BookingToolbar` / `ReorderReasonDialog` / `BookingCalendarModal` / `ConfirmDialog` call sites rewired. `showFilters`, `scrollDir`, grid wiring, `columns` memo untouched.
- **New** `src/test/useBookingModals.test.ts` — 9 cases: init state, per-modal open/close, cross-modal independence, and the reason-only-clears-on-successful-confirm nuance.

## Behavior parity

No UI / behavior / data-flow change. Key nuance preserved: `onOpenChange` and Cancel close the reorder dialog **without** clearing `reorderReason`; only a successful confirm (`resetReorder`) clears it.

## Gates

- `type-check` — pass
- `test` — full suite 76 files / 742 tests pass
- `lint` — clean on touched files (repo-wide CRLF failures are a pre-existing Windows `core.autocrlf` condition, unrelated)
- `build` — compile + type-validation + 27/27 static pages pass; fails only at Next.js standalone symlink tracing (Windows non-admin `EPERM`, environmental)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGyniZFbLBmKKQZxY4t8YS