### PR TITLE
refactor(call-list): adopt the Booking extraction pattern (#180)

### DIFF
--- a/FINDING_STAGE_EXTRACTION_REUSE.md
+++ b/FINDING_STAGE_EXTRACTION_REUSE.md
@@ -1,0 +1,97 @@
+# Finding — Stage extraction pattern: stage-specific hooks vs. a shared generic hook
+
+**Issue:** #180 ([Q4] Call List: adopt the extraction pattern) — child of spec #174.
+**Date:** 2026-09-05
+**Status:** Decision recorded. Default kept: **stage-specific**. Revisit trigger defined below.
+
+## Context
+
+The Booking pilot (#175–#178) established a four-part extraction shape for a stage page:
+
+| Part | Booking artifact |
+|---|---|
+| Action-handler hook | `src/app/(app)/booking/useBookingPageActions.ts` |
+| Shared reorder dialog | `src/components/shared/ReorderReasonDialog.tsx` (parameterized, adopted) |
+| Toolbar component | `src/components/booking/BookingToolbar.tsx` |
+| Modal-state hook | `src/app/(app)/booking/useBookingModals.ts` |
+
+Call List (#180) is the **second** stage to adopt it, which is the point at which the spec asks
+whether cross-stage reuse of the *hooks* (not the already-shared dialog/builders) is warranted.
+
+We now have **three** data points for the action-handler hook:
+
+- `src/app/(app)/orders/useOrdersPageHandlers.ts` (pre-pattern, ~525 LOC)
+- `src/app/(app)/booking/useBookingPageActions.ts` (~113 LOC)
+- `src/app/(app)/call-list/useCallListPageActions.ts` (~121 LOC, this ticket)
+
+## Evidence
+
+### What is genuinely identical across Booking and Call List (plumbing)
+
+- **Param object shape:** `{ applyCommand, effectiveRows, selectedRows, setSelectedRows }`.
+- **`handleUpdateOrder`:** identical body — `applyCommand({ type: "patchRow", … })` with `previousValues: {}`,
+  returns `Promise.resolve()`. Only the stage string literal differs.
+- **`handleSendToArchive`:** identical body — `ids.flatMap` row resolution (drops unknown ids), then
+  `for (const cmd of buildSendToArchiveCommands(rows, reason, <stage>)) applyCommand(cmd)`.
+- **`handleUpdatePartStatus`:** identical — empty-selection guard, `forEach` patch via `handleUpdateOrder`,
+  success toast. (Orders' version is unrelated — it also does VIN auto-move to Call List.)
+
+That is ~40% of each hook by line count.
+
+### What differs and is load-bearing
+
+| Axis | Booking | Call List |
+|---|---|---|
+| Stage literal | `"booking"` (typed enum member, appears ~6×) | `"call"` |
+| Reorder builder | `buildReorderCommands(rows, "booking", reason)` | `buildReorderCommands(rows, "call", reason)` |
+| "Calendar" action | `buildRebookingCommands` (reschedule in place) | `buildBookingCommands` (send **to** Booking) |
+| Handler count | 6 | 7 (adds `handleDelete` empty-selection **gate** with its own `toast.error("Please select at least one row")`, kept per AC even though the button is also `disabled`) |
+| "Calendar" confirm handler | rebooking: guards `if (selectedRows.length === 0) return;`, ignores `applyCommand` return, `onComplete()` **before** `setSelectedRows([])`; `BookingCalendarModal` does **not** self-close, so Booking's page passes `closeRebooking` as `onComplete` | `handleConfirmBooking`: no guard, no `onComplete` param — same as Main Sheet and Archive, which also pass no close callback |
+| `handleConfirmDelete` | takes `onComplete`, calls it last | **no** `onComplete` (shared `ConfirmDialog` calls `onOpenChange(false)` itself) |
+| Toast copy | "Rescheduled N booking(s) successfully", "Booking(s) deleted" | "N row(s) sent to Booking", "Row(s) deleted", "N row(s) sent back to Orders (Reorder)" |
+| Completion ordering | reorder: `applyCommand → setSelectedRows → onComplete → toast`; rebooking: `applyCommand → onComplete → setSelectedRows → toast` (not internally consistent) | reorder: `applyCommand → setSelectedRows → onComplete → toast`; delete has no `onComplete` |
+
+`useOrdersPageHandlers` is **not the same kind of object** at all: it owns data (`useOrdersQuery`,
+`useDraftSession`), local state (`gridApi`, `selectedRows`, six modal flags), effects
+(`checkNotifications`, `useSelectedRowsSync`), and ~15 handlers, most Orders-only (Beast-Mode
+`handleSaveOrder`, `handleCommit`/`handleConfirmCommit`, `handleSendToCallList`,
+`handleShareToLogistics`, `handleSetAllRDate`, bulk attachment, print). It cannot be a client of a
+generic stage-actions hook without being decomposed first.
+
+The modal-state hooks (`useBookingModals` / `useCallListModals`) tell the same story: near-identical
+shape (reorder open + reason + `resetReorder`; one calendar modal; delete confirm) diverging only in
+which calendar modal (`isRebookingModalOpen` vs. `isBookingModalOpen`) and naming.
+
+## Decision
+
+**Keep the hooks stage-specific.** Do not introduce a shared generic
+`useStageActions(stage, { builders, messages })` / `useStageModals()` now.
+
+Rationale:
+
+1. **The divergences are the hard part.** A generic hook would have to be parameterized on the stage
+   enum member, 3+ builder functions, ~6 toast message templates, per-handler completion ordering, and
+   the per-handler `onComplete` shape (plus the `applied`-guard pattern that Orders alone uses). That
+   configuration object is larger and
+   less readable than a ~120-line sibling that is mostly plain `patchRow`-shaped literals.
+2. **The reuse that pays off was already extracted at the right seam.** `ReorderReasonDialog` (shared,
+   prop-parameterized) and the command builders in `@/lib/orderStageTransitions` (pure functions) are
+   where the real duplication lived. What remains in the hooks is shallow and stable.
+3. **Two siblings is not a pattern yet.** The DRY case strengthens with each near-identical instance;
+   it does not clear the bar at n=2 when n=2 already disagree on toast copy, builder choice, and
+   control flow.
+4. **Cost of being wrong is low.** If stages 3–4 confirm the shape, factoring two 120-line hooks into
+   one generic hook later is a mechanical, well-tested refactor. Building the abstraction now and
+   discovering Main Sheet / Archive need yet more knobs is the more expensive mistake.
+
+## Revisit trigger (for Main Sheet #Q? and Archive #Q?)
+
+Adopt a shared generic hook once **both** remaining stages have landed their stage-specific
+action-handler hook **and** all four hooks turn out to differ only by:
+
+- the stage enum literal, and
+- the stage noun inside otherwise-identical toast templates,
+
+i.e. the builder set, the completion ordering, and the `onComplete`/guard shape are the same across
+all four. Track those three axes explicitly when implementing Main Sheet and Archive. If they still
+diverge at n=4, stay stage-specific permanently.

--- a/src/app/(app)/call-list/page.tsx
+++ b/src/app/(app)/call-list/page.tsx
@@ -1,55 +1,17 @@
 "use client";
 
 import type { GridApi } from "ag-grid-community";
-import {
-	Archive,
-	Calendar,
-	CheckCircle,
-	Download,
-	Filter,
-	RotateCcw,
-	Tag,
-	Trash2,
-} from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { useEffect, useMemo, useState } from "react";
+import { CallListToolbar } from "@/components/call-list/CallListToolbar";
 import { DynamicDataGrid as DataGrid } from "@/components/grid";
 import { BookingCalendarModal } from "@/components/shared/BookingCalendarModal";
-import { CallCustomerCounter } from "@/components/shared/CallCustomerCounter";
-import { CallRepairSystemFilter } from "@/components/shared/CallRepairSystemFilter";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { getCallColumns } from "@/components/shared/GridConfig";
 import { InfoLabel } from "@/components/shared/InfoLabel";
-import { LayoutSaveButton } from "@/components/shared/LayoutSaveButton";
+import { ReorderReasonDialog } from "@/components/shared/ReorderReasonDialog";
 import { RowModals } from "@/components/shared/RowModals";
-import { SelectAllByVinButton } from "@/components/shared/SelectAllByVinButton";
-import { Button } from "@/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
-	filterReservedRows,
-	getSelectedIds,
-} from "@/domain/order/orderWorkflow";
+import { filterReservedRows } from "@/domain/order/orderWorkflow";
 import { useOrdersQuery } from "@/hooks/queries/useOrdersQuery";
-import { useColumnLayoutTracker } from "@/hooks/useColumnLayoutTracker";
 import { useDraftSession } from "@/hooks/useDraftSession";
 import { useRowModals } from "@/hooks/useRowModals";
 import { useSelectAllByVin } from "@/hooks/useSelectAllByVin";
@@ -58,20 +20,13 @@ import {
 	filterRowsByRepairSystems,
 	getRepairSystemFilterOptions,
 } from "@/lib/callRepairSystemFilter";
-import {
-	buildBookingCommands,
-	buildReorderCommands,
-	buildSendToArchiveCommands,
-} from "@/lib/orderStageTransitions";
 import { printReservationLabels } from "@/lib/printing/reservationLabels";
-import { cn } from "@/lib/utils";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
+import { useCallListModals } from "./useCallListModals";
+import { useCallListPageActions } from "./useCallListPageActions";
 
 export default function CallListPage() {
-	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
-		useColumnLayoutTracker("call-list");
-	const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
 	const { data: callRowData = [] } = useOrdersQuery("call");
 
 	// Draft session for undo/redo
@@ -102,9 +57,21 @@ export default function CallListPage() {
 		selectedRows,
 		gridApi,
 	);
-	const [isReorderModalOpen, setIsReorderModalOpen] = useState(false);
-	const [reorderReason, setReorderReason] = useState("");
-	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+	const {
+		isReorderModalOpen,
+		setReorderModalOpen,
+		openReorder,
+		closeReorder,
+		reorderReason,
+		setReorderReason,
+		resetReorder,
+		isBookingModalOpen,
+		setBookingModalOpen,
+		openBooking,
+		showDeleteConfirm,
+		setShowDeleteConfirm,
+		openDeleteConfirm,
+	} = useCallListModals();
 	const [showFilters, setShowFilters] = useState(false);
 	const [scrollDir, setScrollDir] = useState<"vertical" | "horizontal">(
 		"vertical",
@@ -141,33 +108,20 @@ export default function CallListPage() {
 		setSelectedRows,
 	);
 
-	const handleUpdateOrder = useCallback(
-		(id: string, updates: Partial<PendingRow>) => {
-			applyCommand({
-				type: "patchRow",
-				id,
-				sourceStage: "call",
-				destinationStage: "call",
-				updates,
-				previousValues: {},
-			});
-			return Promise.resolve();
-		},
-		[applyCommand],
-	);
-
-	const handleSendToArchive = useCallback(
-		(ids: string[], reason: string) => {
-			const rows = ids.flatMap((id) => {
-				const row = effectiveData.find((r: PendingRow) => r.id === id);
-				return row ? [row] : [];
-			});
-			for (const cmd of buildSendToArchiveCommands(rows, reason, "call")) {
-				applyCommand(cmd);
-			}
-		},
-		[effectiveData, applyCommand],
-	);
+	const {
+		handleUpdateOrder,
+		handleSendToArchive,
+		handleConfirmBooking,
+		handleConfirmReorder,
+		handleUpdatePartStatus,
+		handleDelete,
+		handleConfirmDelete,
+	} = useCallListPageActions({
+		applyCommand,
+		effectiveRows: effectiveData,
+		selectedRows,
+		setSelectedRows,
+	});
 
 	const {
 		activeModal,
@@ -192,251 +146,37 @@ export default function CallListPage() {
 		);
 	}, [partStatuses, handleNoteClick, handleReminderClick, handleAttachClick]);
 
-	const handleConfirmBooking = async (
-		date: string,
-		note: string,
-		status?: string,
-	) => {
-		for (const cmd of buildBookingCommands(
-			selectedRows,
-			"call",
-			date,
-			note,
-			status,
-		)) {
-			applyCommand(cmd);
-		}
-		setSelectedRows([]);
-		toast.success(`${selectedRows.length} row(s) sent to Booking`);
-	};
-
-	const handleConfirmReorder = async () => {
-		if (!reorderReason.trim()) {
-			toast.error("Please provide a reason for reorder");
-			return;
-		}
-		for (const cmd of buildReorderCommands(
-			selectedRows,
-			"call",
-			reorderReason,
-		)) {
-			applyCommand(cmd);
-		}
-		setSelectedRows([]);
-		setIsReorderModalOpen(false);
-		setReorderReason("");
-		toast.success(
-			`${selectedRows.length} row(s) sent back to Orders (Reorder)`,
-		);
-	};
-
-	const handleUpdatePartStatus = (status: string) => {
-		if (selectedRows.length === 0) return;
-		selectedRows.forEach((row) => {
-			handleUpdateOrder(row.id, { status });
-		});
-		toast.success(`Updated ${selectedRows.length} item(s) to ${status}`);
-	};
-
-	const handleDelete = () => {
-		if (selectedRows.length === 0) {
-			toast.error("Please select at least one row");
-			return;
-		}
-		setShowDeleteConfirm(true);
-	};
-
 	return (
 		<div className="space-y-4 h-full flex flex-col">
 			<InfoLabel data={selectedRows[0] || null} />
 
-			<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
-				<div className="flex items-center gap-1.5">
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
-								onClick={() => gridApi?.exportDataAsCsv()}
-							>
-								<Download className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Extract</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-gray-400 hover:text-white h-8 w-8"
-								onClick={() => setShowFilters(!showFilters)}
-							>
-								<Filter className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Filter</TooltipContent>
-					</Tooltip>
-
-					<LayoutSaveButton
-						isDirty={isDirty}
-						isPositionDirty={isPositionDirty}
-						onSave={saveLayout}
-						onSaveAsDefault={saveAsDefault}
-						onReset={resetLayout}
-					/>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-gray-400 hover:text-white h-8 w-8"
-								onClick={() => {
-									const reservedRows = filterReservedRows(
-										selectedRows,
-										partStatuses,
-									);
-									if (reservedRows.length === 0) return;
-									printReservationLabels(reservedRows);
-								}}
-								disabled={selectedRows.length === 0}
-							>
-								<Tag className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Reserve/Print Label</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon"
-										className="text-gray-400 hover:text-white h-8 w-8"
-										disabled={selectedRows.length === 0}
-									>
-										<CheckCircle className="h-4 w-4" />
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent
-									align="end"
-									className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
-								>
-									{partStatuses?.map((status) => {
-										const isHex =
-											status.color?.startsWith("#") ||
-											status.color?.startsWith("rgb");
-										const dotStyle = isHex
-											? { backgroundColor: status.color }
-											: undefined;
-										const colorClass = isHex ? "" : status.color;
-
-										return (
-											<DropdownMenuItem
-												key={status.id}
-												onClick={() => handleUpdatePartStatus(status.label)}
-												className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
-											>
-												<div
-													className={cn("w-2 h-2 rounded-full", colorClass)}
-													style={dotStyle}
-												/>
-												<span className="text-xs">{status.label}</span>
-											</DropdownMenuItem>
-										);
-									})}
-								</DropdownMenuContent>
-							</DropdownMenu>
-						</TooltipTrigger>
-						<TooltipContent>Update Status</TooltipContent>
-					</Tooltip>
-
-					<div className="w-px h-5 bg-white/10 mx-1" />
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-green-500/80 hover:text-green-500 h-8 w-8"
-								disabled={selectedRows.length === 0}
-								onClick={() => setIsBookingModalOpen(true)}
-							>
-								<Calendar className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Send to Booking</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
-								disabled={selectedRows.length === 0}
-								onClick={() => setIsReorderModalOpen(true)}
-							>
-								<RotateCcw className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Send to Reorder</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-gray-400 hover:text-white h-8 w-8"
-								disabled={selectedRows.length === 0}
-								onClick={() =>
-									handleArchiveClick(
-										selectedRows[0],
-										selectedRows.map((r) => r.id),
-									)
-								}
-							>
-								<Archive className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Archive</TooltipContent>
-					</Tooltip>
-
-					<CallRepairSystemFilter
-						options={repairSystemOptions}
-						value={selectedRepairSystems}
-						onChange={setSelectedRepairSystems}
-					/>
-				</div>
-
-				<div className="flex items-center gap-1.5">
-					<SelectAllByVinButton
-						onSelectAllByVin={onSelectAllByVin}
-						isDisabled={isSelectAllByVinDisabled}
-					/>
-					<CallCustomerCounter rows={filteredEffectiveData} />
-					<div className="w-px h-5 bg-white/10 mx-1" />
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
-								onClick={handleDelete}
-								disabled={selectedRows.length === 0}
-							>
-								<Trash2 className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Delete</TooltipContent>
-					</Tooltip>
-				</div>
-			</div>
+			<CallListToolbar
+				selectedRows={selectedRows}
+				partStatuses={partStatuses}
+				rowData={filteredEffectiveData}
+				repairSystemOptions={repairSystemOptions}
+				selectedRepairSystems={selectedRepairSystems}
+				onRepairSystemsChange={setSelectedRepairSystems}
+				onExtract={() => gridApi?.exportDataAsCsv()}
+				onFilterToggle={() => setShowFilters(!showFilters)}
+				onReserve={() => {
+					const reservedRows = filterReservedRows(selectedRows, partStatuses);
+					if (reservedRows.length === 0) return;
+					printReservationLabels(reservedRows);
+				}}
+				onUpdateStatus={handleUpdatePartStatus}
+				onSendToBooking={openBooking}
+				onReorder={openReorder}
+				onArchive={() =>
+					handleArchiveClick(
+						selectedRows[0],
+						selectedRows.map((r) => r.id),
+					)
+				}
+				onDelete={() => handleDelete(() => openDeleteConfirm())}
+				onSelectAllByVin={onSelectAllByVin}
+				isSelectAllByVinDisabled={isSelectAllByVinDisabled}
+			/>
 
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
 			<div
@@ -484,49 +224,20 @@ export default function CallListPage() {
 				/>
 			</div>
 
-			<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
-				<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
-					<DialogHeader>
-						<DialogTitle className="text-orange-500">
-							Reorder - Reason Required
-						</DialogTitle>
-					</DialogHeader>
-					<div className="space-y-4">
-						<div>
-							<Label>Reason for Reorder</Label>
-							<Input
-								value={reorderReason}
-								onChange={(e) => setReorderReason(e.target.value)}
-								placeholder="e.g., Wrong part, Customer cancelled"
-								className="bg-white/5 border-white/10 text-white"
-							/>
-						</div>
-						<p className="text-sm text-muted-foreground">
-							This will send the selected items back to the Orders view.
-						</p>
-					</div>
-					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setIsReorderModalOpen(false)}
-							className="border-white/20 text-white hover:bg-white/10"
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="renault"
-							onClick={handleConfirmReorder}
-							disabled={!reorderReason.trim()}
-						>
-							Confirm Reorder
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<ReorderReasonDialog
+				open={isReorderModalOpen}
+				onOpenChange={setReorderModalOpen}
+				reason={reorderReason}
+				onReasonChange={setReorderReason}
+				onCancel={closeReorder}
+				onConfirm={() => handleConfirmReorder(reorderReason, resetReorder)}
+				placeholder="e.g., Wrong part, Customer cancelled"
+				helperText="This will send the selected items back to the Orders view."
+			/>
 
 			<BookingCalendarModal
 				open={isBookingModalOpen}
-				onOpenChange={setIsBookingModalOpen}
+				onOpenChange={setBookingModalOpen}
 				onConfirm={handleConfirmBooking}
 				selectedRows={selectedRows}
 			/>
@@ -544,14 +255,7 @@ export default function CallListPage() {
 			<ConfirmDialog
 				open={showDeleteConfirm}
 				onOpenChange={setShowDeleteConfirm}
-				onConfirm={async () => {
-					applyCommand({
-						type: "deleteRows",
-						ids: getSelectedIds(selectedRows),
-					});
-					setSelectedRows([]);
-					toast.success("Row(s) deleted");
-				}}
+				onConfirm={handleConfirmDelete}
 				title="Delete Records"
 				description={`Are you sure you want to delete ${selectedRows.length} selected record(s)?`}
 				confirmText="Delete"

--- a/src/app/(app)/call-list/useCallListModals.ts
+++ b/src/app/(app)/call-list/useCallListModals.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+export function useCallListModals() {
+	const [isReorderModalOpen, setIsReorderModalOpen] = useState(false);
+	const [reorderReason, setReorderReason] = useState("");
+	const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+	return {
+		// reorder
+		isReorderModalOpen,
+		setReorderModalOpen: setIsReorderModalOpen,
+		openReorder: () => setIsReorderModalOpen(true),
+		closeReorder: () => setIsReorderModalOpen(false),
+		reorderReason,
+		setReorderReason,
+		resetReorder: () => {
+			setIsReorderModalOpen(false);
+			setReorderReason("");
+		},
+		// booking calendar modal
+		isBookingModalOpen,
+		setBookingModalOpen: setIsBookingModalOpen,
+		openBooking: () => setIsBookingModalOpen(true),
+		closeBooking: () => setIsBookingModalOpen(false),
+		// delete
+		showDeleteConfirm,
+		setShowDeleteConfirm,
+		openDeleteConfirm: () => setShowDeleteConfirm(true),
+		closeDeleteConfirm: () => setShowDeleteConfirm(false),
+	};
+}

--- a/src/app/(app)/call-list/useCallListPageActions.ts
+++ b/src/app/(app)/call-list/useCallListPageActions.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import type React from "react";
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { getSelectedIds } from "@/domain/order/orderWorkflow";
+import type { useDraftSession } from "@/hooks/useDraftSession";
+import {
+	buildBookingCommands,
+	buildReorderCommands,
+	buildSendToArchiveCommands,
+} from "@/lib/orderStageTransitions";
+import type { PendingRow } from "@/types";
+
+export function useCallListPageActions(params: {
+	applyCommand: ReturnType<typeof useDraftSession>["applyCommand"];
+	effectiveRows: PendingRow[];
+	selectedRows: PendingRow[];
+	setSelectedRows: React.Dispatch<React.SetStateAction<PendingRow[]>>;
+}) {
+	const { applyCommand, effectiveRows, selectedRows, setSelectedRows } = params;
+
+	const handleUpdateOrder = useCallback(
+		(id: string, updates: Partial<PendingRow>) => {
+			applyCommand({
+				type: "patchRow",
+				id,
+				sourceStage: "call",
+				destinationStage: "call",
+				updates,
+				previousValues: {},
+			});
+			return Promise.resolve();
+		},
+		[applyCommand],
+	);
+
+	const handleSendToArchive = useCallback(
+		(ids: string[], reason: string) => {
+			const rows = ids.flatMap((id) => {
+				const row = effectiveRows.find((r: PendingRow) => r.id === id);
+				return row ? [row] : [];
+			});
+			for (const cmd of buildSendToArchiveCommands(rows, reason, "call")) {
+				applyCommand(cmd);
+			}
+		},
+		[effectiveRows, applyCommand],
+	);
+
+	const handleConfirmBooking = async (
+		date: string,
+		note: string,
+		status?: string,
+	) => {
+		for (const cmd of buildBookingCommands(
+			selectedRows,
+			"call",
+			date,
+			note,
+			status,
+		)) {
+			applyCommand(cmd);
+		}
+		setSelectedRows([]);
+		toast.success(`${selectedRows.length} row(s) sent to Booking`);
+	};
+
+	const handleConfirmReorder = async (
+		reason: string,
+		onComplete: () => void,
+	) => {
+		if (!reason.trim()) {
+			toast.error("Please provide a reason for reorder");
+			return;
+		}
+		for (const cmd of buildReorderCommands(selectedRows, "call", reason)) {
+			applyCommand(cmd);
+		}
+		setSelectedRows([]);
+		onComplete();
+		toast.success(
+			`${selectedRows.length} row(s) sent back to Orders (Reorder)`,
+		);
+	};
+
+	const handleUpdatePartStatus = (status: string) => {
+		if (selectedRows.length === 0) return;
+		selectedRows.forEach((row) => {
+			handleUpdateOrder(row.id, { status });
+		});
+		toast.success(`Updated ${selectedRows.length} item(s) to ${status}`);
+	};
+
+	const handleDelete = (onProceed: () => void) => {
+		if (selectedRows.length === 0) {
+			toast.error("Please select at least one row");
+			return;
+		}
+		onProceed();
+	};
+
+	const handleConfirmDelete = async () => {
+		applyCommand({
+			type: "deleteRows",
+			ids: getSelectedIds(selectedRows),
+		});
+		setSelectedRows([]);
+		toast.success("Row(s) deleted");
+	};
+
+	return {
+		handleUpdateOrder,
+		handleSendToArchive,
+		handleConfirmBooking,
+		handleConfirmReorder,
+		handleUpdatePartStatus,
+		handleDelete,
+		handleConfirmDelete,
+	};
+}

--- a/src/components/call-list/CallListToolbar.tsx
+++ b/src/components/call-list/CallListToolbar.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import {
+	Archive,
+	Calendar,
+	CheckCircle,
+	Download,
+	Filter,
+	RotateCcw,
+	Tag,
+	Trash2,
+} from "lucide-react";
+import { CallCustomerCounter } from "@/components/shared/CallCustomerCounter";
+import { CallRepairSystemFilter } from "@/components/shared/CallRepairSystemFilter";
+import { LayoutSaveButton } from "@/components/shared/LayoutSaveButton";
+import { SelectAllByVinButton } from "@/components/shared/SelectAllByVinButton";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useColumnLayoutTracker } from "@/hooks/useColumnLayoutTracker";
+import type { RepairSystemFilterOption } from "@/lib/callRepairSystemFilter";
+import { cn } from "@/lib/utils";
+import type { PartStatusDef, PendingRow } from "@/types";
+
+export interface CallListToolbarProps {
+	selectedRows: PendingRow[];
+	partStatuses?: PartStatusDef[];
+	rowData?: PendingRow[];
+	repairSystemOptions: RepairSystemFilterOption[];
+	selectedRepairSystems: string[];
+	onRepairSystemsChange: (value: string[]) => void;
+	onExtract: () => void;
+	onFilterToggle: () => void;
+	onReserve: () => void;
+	onUpdateStatus: (statusLabel: string) => void;
+	onSendToBooking: () => void;
+	onReorder: () => void;
+	onArchive: () => void;
+	onDelete: () => void;
+	onSelectAllByVin: () => void;
+	isSelectAllByVinDisabled: boolean;
+}
+
+export function CallListToolbar({
+	selectedRows = [],
+	partStatuses = [],
+	rowData = [],
+	repairSystemOptions,
+	selectedRepairSystems,
+	onRepairSystemsChange,
+	onExtract,
+	onFilterToggle,
+	onReserve,
+	onUpdateStatus,
+	onSendToBooking,
+	onReorder,
+	onArchive,
+	onDelete,
+	onSelectAllByVin,
+	isSelectAllByVinDisabled,
+}: CallListToolbarProps) {
+	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
+		useColumnLayoutTracker("call-list");
+
+	return (
+		<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
+			<div className="flex items-center gap-1.5">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
+							onClick={onExtract}
+						>
+							<Download className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Extract</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-gray-400 hover:text-white h-8 w-8"
+							onClick={onFilterToggle}
+						>
+							<Filter className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Filter</TooltipContent>
+				</Tooltip>
+
+				<LayoutSaveButton
+					isDirty={isDirty}
+					isPositionDirty={isPositionDirty}
+					onSave={saveLayout}
+					onSaveAsDefault={saveAsDefault}
+					onReset={resetLayout}
+				/>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-gray-400 hover:text-white h-8 w-8"
+							onClick={onReserve}
+							disabled={selectedRows.length === 0}
+						>
+							<Tag className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Reserve/Print Label</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="text-gray-400 hover:text-white h-8 w-8"
+									disabled={selectedRows.length === 0}
+								>
+									<CheckCircle className="h-4 w-4" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								align="end"
+								className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
+							>
+								{partStatuses?.map((status) => {
+									const isHex =
+										status.color?.startsWith("#") ||
+										status.color?.startsWith("rgb");
+									const dotStyle = isHex
+										? { backgroundColor: status.color }
+										: undefined;
+									const colorClass = isHex ? "" : status.color;
+
+									return (
+										<DropdownMenuItem
+											key={status.id}
+											onClick={() => onUpdateStatus(status.label)}
+											className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
+										>
+											<div
+												className={cn("w-2 h-2 rounded-full", colorClass)}
+												style={dotStyle}
+											/>
+											<span className="text-xs">{status.label}</span>
+										</DropdownMenuItem>
+									);
+								})}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</TooltipTrigger>
+					<TooltipContent>Update Status</TooltipContent>
+				</Tooltip>
+
+				<div className="w-px h-5 bg-white/10 mx-1" />
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-green-500/80 hover:text-green-500 h-8 w-8"
+							disabled={selectedRows.length === 0}
+							onClick={onSendToBooking}
+						>
+							<Calendar className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Send to Booking</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
+							disabled={selectedRows.length === 0}
+							onClick={onReorder}
+						>
+							<RotateCcw className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Send to Reorder</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-gray-400 hover:text-white h-8 w-8"
+							disabled={selectedRows.length === 0}
+							onClick={onArchive}
+						>
+							<Archive className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Archive</TooltipContent>
+				</Tooltip>
+
+				<CallRepairSystemFilter
+					options={repairSystemOptions}
+					value={selectedRepairSystems}
+					onChange={onRepairSystemsChange}
+				/>
+			</div>
+
+			<div className="flex items-center gap-1.5">
+				<SelectAllByVinButton
+					onSelectAllByVin={onSelectAllByVin}
+					isDisabled={isSelectAllByVinDisabled}
+				/>
+				<CallCustomerCounter rows={rowData} />
+				<div className="w-px h-5 bg-white/10 mx-1" />
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
+							onClick={onDelete}
+							disabled={selectedRows.length === 0}
+						>
+							<Trash2 className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Delete</TooltipContent>
+				</Tooltip>
+			</div>
+		</div>
+	);
+}

--- a/src/test/CallListToolbar.test.tsx
+++ b/src/test/CallListToolbar.test.tsx
@@ -1,0 +1,178 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+	CallListToolbar,
+	type CallListToolbarProps,
+} from "@/components/call-list/CallListToolbar";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { PartStatusDef, PendingRow } from "@/types";
+
+const renderWithProvider = (ui: React.ReactElement) => {
+	return render(<TooltipProvider>{ui}</TooltipProvider>);
+};
+
+const getButtonByIcon = (container: HTMLElement, iconClass: string) => {
+	const btn = container.querySelector(`.${iconClass}`)?.closest("button");
+	if (!btn) {
+		throw new Error(`Button with icon .${iconClass} not found`);
+	}
+	return btn;
+};
+
+const mockSelectedRows: PendingRow[] = [
+	{
+		id: "1",
+		vin: "VF1BB0A0F12345678",
+		customerName: "Test Customer",
+		stage: "call",
+	} as PendingRow,
+];
+
+const mockPartStatuses: PartStatusDef[] = [
+	{ id: "1", label: "Reserve", color: "#ff0000" },
+	{ id: "2", label: "Under Inspection", color: "text-blue-500" },
+];
+
+const defaultProps: CallListToolbarProps = {
+	selectedRows: mockSelectedRows,
+	partStatuses: mockPartStatuses,
+	rowData: mockSelectedRows,
+	repairSystemOptions: [{ label: "Brakes", value: "Brakes" }],
+	selectedRepairSystems: [],
+	onRepairSystemsChange: vi.fn(),
+	onExtract: vi.fn(),
+	onFilterToggle: vi.fn(),
+	onReserve: vi.fn(),
+	onUpdateStatus: vi.fn(),
+	onSendToBooking: vi.fn(),
+	onReorder: vi.fn(),
+	onArchive: vi.fn(),
+	onDelete: vi.fn(),
+	onSelectAllByVin: vi.fn(),
+	isSelectAllByVinDisabled: false,
+};
+
+describe("CallListToolbar", () => {
+	it("disables Reserve, Update Status, Send to Booking, Send to Reorder, Archive, and Delete when selectedRows is empty", () => {
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} selectedRows={[]} />,
+		);
+
+		expect(getButtonByIcon(container, "lucide-tag")).toBeDisabled();
+		expect(
+			getButtonByIcon(container, "lucide-circle-check-big"),
+		).toBeDisabled();
+		expect(getButtonByIcon(container, "lucide-calendar")).toBeDisabled();
+		expect(getButtonByIcon(container, "lucide-rotate-ccw")).toBeDisabled();
+		expect(getButtonByIcon(container, "lucide-archive")).toBeDisabled();
+		expect(getButtonByIcon(container, "lucide-trash2")).toBeDisabled();
+	});
+
+	it("enables action buttons when rows are selected", () => {
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} selectedRows={mockSelectedRows} />,
+		);
+
+		expect(getButtonByIcon(container, "lucide-tag")).toBeEnabled();
+		expect(getButtonByIcon(container, "lucide-circle-check-big")).toBeEnabled();
+		expect(getButtonByIcon(container, "lucide-calendar")).toBeEnabled();
+		expect(getButtonByIcon(container, "lucide-rotate-ccw")).toBeEnabled();
+		expect(getButtonByIcon(container, "lucide-archive")).toBeEnabled();
+		expect(getButtonByIcon(container, "lucide-trash2")).toBeEnabled();
+	});
+
+	it("calls onExtract when Extract is clicked", () => {
+		const onExtract = vi.fn();
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} onExtract={onExtract} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-download");
+		fireEvent.click(btn);
+		expect(onExtract).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onFilterToggle when Filter is clicked", () => {
+		const onFilterToggle = vi.fn();
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} onFilterToggle={onFilterToggle} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-filter");
+		fireEvent.click(btn);
+		expect(onFilterToggle).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onReserve when Reserve button is clicked", () => {
+		const onReserve = vi.fn();
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} onReserve={onReserve} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-tag");
+		fireEvent.click(btn);
+		expect(onReserve).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onSendToBooking when Booking button is clicked", () => {
+		const onSendToBooking = vi.fn();
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} onSendToBooking={onSendToBooking} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-calendar");
+		fireEvent.click(btn);
+		expect(onSendToBooking).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onReorder when Reorder button is clicked", () => {
+		const onReorder = vi.fn();
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} onReorder={onReorder} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-rotate-ccw");
+		fireEvent.click(btn);
+		expect(onReorder).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onArchive when Archive button is clicked", () => {
+		const onArchive = vi.fn();
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} onArchive={onArchive} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-archive");
+		fireEvent.click(btn);
+		expect(onArchive).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onDelete when Delete button is clicked", () => {
+		const onDelete = vi.fn();
+		const { container } = renderWithProvider(
+			<CallListToolbar {...defaultProps} onDelete={onDelete} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-trash2");
+		fireEvent.click(btn);
+		expect(onDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders items for each partStatus and calls onUpdateStatus when clicked", async () => {
+		const user = userEvent.setup();
+		const onUpdateStatus = vi.fn();
+		const { container } = renderWithProvider(
+			<CallListToolbar
+				{...defaultProps}
+				partStatuses={mockPartStatuses}
+				onUpdateStatus={onUpdateStatus}
+			/>,
+		);
+		const trigger = getButtonByIcon(container, "lucide-circle-check-big");
+		await user.click(trigger);
+
+		const reserveItem = await screen.findByText("Reserve");
+		const inspectionItem = await screen.findByText("Under Inspection");
+		expect(reserveItem).toBeInTheDocument();
+		expect(inspectionItem).toBeInTheDocument();
+
+		await user.click(reserveItem);
+		expect(onUpdateStatus).toHaveBeenCalledWith("Reserve");
+	});
+});

--- a/src/test/ReorderReasonDialogCallList.test.tsx
+++ b/src/test/ReorderReasonDialogCallList.test.tsx
@@ -1,0 +1,108 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ReorderReasonDialog } from "@/components/shared/ReorderReasonDialog";
+
+vi.mock("@/components/ui/dialog", () => ({
+	Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+		open ? <div data-testid="reorder-dialog">{children}</div> : null,
+	DialogContent: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogHeader: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DialogTitle: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogDescription: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogFooter: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+describe("ReorderReasonDialog - Call List adoption", () => {
+	const callListProps = {
+		open: true,
+		onOpenChange: vi.fn(),
+		reason: "",
+		onReasonChange: vi.fn(),
+		onCancel: vi.fn(),
+		onConfirm: vi.fn(),
+		placeholder: "e.g., Wrong part, Customer cancelled",
+		helperText: "This will send the selected items back to the Orders view.",
+	};
+
+	it("renders Call List placeholder and helperText, and does NOT render srDescription", () => {
+		const { container } = render(<ReorderReasonDialog {...callListProps} />);
+
+		expect(
+			screen.getByPlaceholderText("e.g., Wrong part, Customer cancelled"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"This will send the selected items back to the Orders view.",
+			),
+		).toBeInTheDocument();
+
+		// No sr-only description element rendered
+		const srOnlyEl = container.querySelector(".sr-only");
+		expect(srOnlyEl).toBeNull();
+	});
+
+	it("keeps Confirm Reorder disabled when reason is blank, and enables it when filled", () => {
+		const { rerender } = render(
+			<ReorderReasonDialog {...callListProps} reason="" />,
+		);
+
+		const confirmBtn = screen.getByRole("button", {
+			name: /confirm reorder/i,
+		});
+		expect(confirmBtn).toBeDisabled();
+
+		rerender(<ReorderReasonDialog {...callListProps} reason="   " />);
+		expect(confirmBtn).toBeDisabled();
+
+		rerender(
+			<ReorderReasonDialog {...callListProps} reason="Defective part" />,
+		);
+		expect(confirmBtn).toBeEnabled();
+	});
+
+	it("calls onConfirm when Confirm Reorder is clicked with non-empty reason", () => {
+		const onConfirm = vi.fn();
+		render(
+			<ReorderReasonDialog
+				{...callListProps}
+				reason="Defective part"
+				onConfirm={onConfirm}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /confirm reorder/i }));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		const onCancel = vi.fn();
+		render(<ReorderReasonDialog {...callListProps} onCancel={onCancel} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/test/useCallListModals.test.ts
+++ b/src/test/useCallListModals.test.ts
@@ -1,0 +1,190 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useCallListModals } from "@/app/(app)/call-list/useCallListModals";
+
+describe("useCallListModals", () => {
+	it("initializes with all modals closed and an empty reorderReason", () => {
+		const { result } = renderHook(() => useCallListModals());
+
+		expect(result.current.isReorderModalOpen).toBe(false);
+		expect(result.current.reorderReason).toBe("");
+		expect(result.current.isBookingModalOpen).toBe(false);
+		expect(result.current.showDeleteConfirm).toBe(false);
+	});
+
+	describe("reorder modal", () => {
+		it("openReorder() opens modal; closeReorder() closes it and leaves reorderReason unchanged", () => {
+			const { result } = renderHook(() => useCallListModals());
+
+			act(() => {
+				result.current.setReorderReason("Wrong part supplied");
+			});
+			expect(result.current.reorderReason).toBe("Wrong part supplied");
+
+			act(() => {
+				result.current.openReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+
+			act(() => {
+				result.current.closeReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("Wrong part supplied");
+		});
+
+		it("resetReorder() closes modal and clears reorderReason to empty string", () => {
+			const { result } = renderHook(() => useCallListModals());
+
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Customer cancelled");
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.reorderReason).toBe("Customer cancelled");
+
+			act(() => {
+				result.current.resetReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("");
+		});
+
+		it("setReorderModalOpen(false) (the onOpenChange path) closes without clearing a set reason", () => {
+			const { result } = renderHook(() => useCallListModals());
+
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Part defective");
+			});
+
+			act(() => {
+				result.current.setReorderModalOpen(false);
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("Part defective");
+
+			act(() => {
+				result.current.setReorderModalOpen(true);
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.reorderReason).toBe("Part defective");
+		});
+	});
+
+	describe("booking calendar modal", () => {
+		it("openBooking() and closeBooking() toggle isBookingModalOpen only", () => {
+			const { result } = renderHook(() => useCallListModals());
+
+			act(() => {
+				result.current.openBooking();
+			});
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+
+			act(() => {
+				result.current.closeBooking();
+			});
+			expect(result.current.isBookingModalOpen).toBe(false);
+		});
+
+		it("setBookingModalOpen() directly controls isBookingModalOpen for onOpenChange", () => {
+			const { result } = renderHook(() => useCallListModals());
+
+			act(() => {
+				result.current.setBookingModalOpen(true);
+			});
+			expect(result.current.isBookingModalOpen).toBe(true);
+
+			act(() => {
+				result.current.setBookingModalOpen(false);
+			});
+			expect(result.current.isBookingModalOpen).toBe(false);
+		});
+	});
+
+	describe("delete confirm modal", () => {
+		it("openDeleteConfirm() and closeDeleteConfirm() toggle showDeleteConfirm only", () => {
+			const { result } = renderHook(() => useCallListModals());
+
+			act(() => {
+				result.current.openDeleteConfirm();
+			});
+			expect(result.current.showDeleteConfirm).toBe(true);
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.isBookingModalOpen).toBe(false);
+
+			act(() => {
+				result.current.closeDeleteConfirm();
+			});
+			expect(result.current.showDeleteConfirm).toBe(false);
+		});
+
+		it("setShowDeleteConfirm() directly controls showDeleteConfirm for onOpenChange", () => {
+			const { result } = renderHook(() => useCallListModals());
+
+			act(() => {
+				result.current.setShowDeleteConfirm(true);
+			});
+			expect(result.current.showDeleteConfirm).toBe(true);
+
+			act(() => {
+				result.current.setShowDeleteConfirm(false);
+			});
+			expect(result.current.showDeleteConfirm).toBe(false);
+		});
+	});
+
+	describe("cross-independence", () => {
+		it("opening one modal does not change the other modals or mutate state unexpectedly", () => {
+			const { result } = renderHook(() => useCallListModals());
+
+			// Open reorder
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Test reason");
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+
+			// Open booking
+			act(() => {
+				result.current.openBooking();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Open delete confirm
+			act(() => {
+				result.current.openDeleteConfirm();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.showDeleteConfirm).toBe(true);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Close booking & delete confirm - reorder remains open with reason intact
+			act(() => {
+				result.current.closeBooking();
+				result.current.closeDeleteConfirm();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Reset reorder clears reason and closes reorder modal
+			act(() => {
+				result.current.resetReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("");
+		});
+	});
+});

--- a/src/test/useCallListPageActions.test.ts
+++ b/src/test/useCallListPageActions.test.ts
@@ -1,0 +1,536 @@
+import { act, renderHook } from "@testing-library/react";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCallListPageActions } from "@/app/(app)/call-list/useCallListPageActions";
+import {
+	buildBookingCommands,
+	buildReorderCommands,
+	buildSendToArchiveCommands,
+} from "@/lib/orderStageTransitions";
+import type { PendingRow } from "@/types";
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock("@/lib/orderStageTransitions", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/orderStageTransitions")>();
+	return {
+		...actual,
+		buildReorderCommands: vi.fn(actual.buildReorderCommands),
+		buildBookingCommands: vi.fn(actual.buildBookingCommands),
+		buildSendToArchiveCommands: vi.fn(actual.buildSendToArchiveCommands),
+	};
+});
+
+const createRow = (overrides: Partial<PendingRow> = {}): PendingRow => ({
+	id: crypto.randomUUID(),
+	baseId: "B1",
+	trackingId: "T1",
+	customerName: "Test Customer",
+	mobile: "123456789",
+	parts: [],
+	status: "Pending",
+	rDate: "2024-01-01",
+	requester: "Admin",
+	acceptedBy: "Admin",
+	sabNumber: "S1",
+	model: "Clio",
+	cntrRdg: 1000,
+	repairSystem: "None",
+	startWarranty: "",
+	endWarranty: "",
+	remainTime: "",
+	partNumber: "P1",
+	description: "Test Part",
+	quantity: 1,
+	vin: "VF1BB0A0F12345678",
+	stage: "call",
+	...overrides,
+});
+
+describe("useCallListPageActions", () => {
+	const applyCommand = vi.fn();
+	const setSelectedRows = vi.fn();
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+		vi.clearAllMocks();
+		applyCommand.mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("handleConfirmReorder", () => {
+		it("rejects reorder when reason is empty or whitespace-only without calling applyCommand, setSelectedRows, or onComplete", async () => {
+			const row = createRow();
+			const onComplete = vi.fn();
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("", onComplete);
+			});
+
+			expect(toast.error).toHaveBeenCalledWith(
+				"Please provide a reason for reorder",
+			);
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(setSelectedRows).not.toHaveBeenCalled();
+			expect(onComplete).not.toHaveBeenCalled();
+
+			vi.clearAllMocks();
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("   ", onComplete);
+			});
+
+			expect(toast.error).toHaveBeenCalledWith(
+				"Please provide a reason for reorder",
+			);
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(setSelectedRows).not.toHaveBeenCalled();
+			expect(onComplete).not.toHaveBeenCalled();
+		});
+
+		it("reorders rows individually, clears selection, calls onComplete, and toasts with correct order", async () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const selected = [row1, row2];
+			const onComplete = vi.fn();
+
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("Damaged item", onComplete);
+			});
+
+			expect(buildReorderCommands).toHaveBeenCalledTimes(1);
+			expect(buildReorderCommands).toHaveBeenCalledWith(
+				selected,
+				"call",
+				"Damaged item",
+			);
+
+			expect(applyCommand).toHaveBeenCalledTimes(selected.length);
+			for (const call of applyCommand.mock.calls) {
+				expect(call[0]).toMatchObject({
+					type: "patchRow",
+					sourceStage: "call",
+					destinationStage: "orders",
+				});
+			}
+
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(onComplete).toHaveBeenCalledTimes(1);
+			expect(toast.success).toHaveBeenCalledWith(
+				"2 row(s) sent back to Orders (Reorder)",
+			);
+
+			// Preserved order: applyCommand -> setSelectedRows -> onComplete -> toast.success
+			const lastApply = Math.max(...applyCommand.mock.invocationCallOrder);
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const complete = onComplete.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(lastApply).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(complete);
+			expect(complete).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleConfirmBooking", () => {
+		it("replays buildBookingCommands output, clears selection, and toasts success", async () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmBooking(
+					"2026-02-15",
+					"Customer requested booking",
+					"Confirmed",
+				);
+			});
+
+			expect(buildBookingCommands).toHaveBeenCalledTimes(1);
+			expect(buildBookingCommands).toHaveBeenCalledWith(
+				selected,
+				"call",
+				"2026-02-15",
+				"Customer requested booking",
+				"Confirmed",
+			);
+
+			expect(applyCommand).toHaveBeenCalledTimes(selected.length);
+			for (const call of applyCommand.mock.calls) {
+				expect(call[0]).toMatchObject({
+					type: "patchRow",
+					sourceStage: "call",
+					destinationStage: "booking",
+				});
+			}
+
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(toast.success).toHaveBeenCalledWith("2 row(s) sent to Booking");
+
+			const lastApply = Math.max(...applyCommand.mock.invocationCallOrder);
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(lastApply).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleUpdatePartStatus", () => {
+		it("updates part status for all selected rows with individual patchRow commands", () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleUpdatePartStatus("Reserve");
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(2);
+			expect(applyCommand).toHaveBeenNthCalledWith(1, {
+				type: "patchRow",
+				id: row1.id,
+				sourceStage: "call",
+				destinationStage: "call",
+				updates: { status: "Reserve" },
+				previousValues: {},
+			});
+			expect(applyCommand).toHaveBeenNthCalledWith(2, {
+				type: "patchRow",
+				id: row2.id,
+				sourceStage: "call",
+				destinationStage: "call",
+				updates: { status: "Reserve" },
+				previousValues: {},
+			});
+			expect(toast.success).toHaveBeenCalledWith(
+				"Updated 2 item(s) to Reserve",
+			);
+		});
+
+		it("no-ops for handleUpdatePartStatus when selectedRows is empty", () => {
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: [],
+					selectedRows: [],
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleUpdatePartStatus("Reserve");
+			});
+
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(toast.success).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("handleDelete", () => {
+		it("toasts error and does not call onProceed when selectedRows is empty", () => {
+			const onProceed = vi.fn();
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: [],
+					selectedRows: [],
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleDelete(onProceed);
+			});
+
+			expect(toast.error).toHaveBeenCalledWith(
+				"Please select at least one row",
+			);
+			expect(onProceed).not.toHaveBeenCalled();
+		});
+
+		it("calls onProceed and does not toast when rows are selected", () => {
+			const row = createRow();
+			const onProceed = vi.fn();
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleDelete(onProceed);
+			});
+
+			expect(toast.error).not.toHaveBeenCalled();
+			expect(onProceed).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("handleConfirmDelete", () => {
+		it("deletes selected rows in a single batch, clears selection, and toasts", async () => {
+			const uuid1 = crypto.randomUUID();
+			const uuid2 = crypto.randomUUID();
+			const row1 = createRow({ id: uuid1 });
+			const row2 = createRow({ id: uuid2 });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmDelete();
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith({
+				type: "deleteRows",
+				ids: [uuid1, uuid2],
+			});
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(toast.success).toHaveBeenCalledWith("Row(s) deleted");
+
+			// Preserved order: applyCommand -> setSelectedRows -> toast.success
+			const applyOrder = applyCommand.mock.invocationCallOrder[0];
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(applyOrder).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleUpdateOrder", () => {
+		it("dispatches patchRow command targeting call stage and resolves", async () => {
+			const row = createRow();
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			let resolvedValue: unknown;
+			await act(async () => {
+				resolvedValue = await result.current.handleUpdateOrder(row.id, {
+					customerName: "New Name",
+				});
+			});
+
+			expect(resolvedValue).toBeUndefined();
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith({
+				type: "patchRow",
+				id: row.id,
+				sourceStage: "call",
+				destinationStage: "call",
+				updates: { customerName: "New Name" },
+				previousValues: {},
+			});
+		});
+	});
+
+	describe("handleSendToArchive", () => {
+		it("preserves ID ordering and silently drops unknown IDs when archiving", () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const row3 = createRow({ id: crypto.randomUUID() });
+			const unknownId = crypto.randomUUID();
+
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: [row1, row2, row3],
+					selectedRows: [],
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleSendToArchive(
+					[row3.id, unknownId, row1.id],
+					"Scrapped",
+				);
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(2);
+			expect(applyCommand).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining({
+					id: row3.id,
+					sourceStage: "call",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						status: "Archived",
+						archiveReason: "Scrapped",
+						archivedAt: "2026-01-01T00:00:00.000Z",
+					}),
+				}),
+			);
+			expect(applyCommand).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					id: row1.id,
+					sourceStage: "call",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						status: "Archived",
+						archiveReason: "Scrapped",
+						archivedAt: "2026-01-01T00:00:00.000Z",
+					}),
+				}),
+			);
+		});
+
+		it("resolves rows from refreshed effectiveRows after rerender", () => {
+			const rowA = createRow({ id: crypto.randomUUID() });
+			const rowB = createRow({ id: crypto.randomUUID() });
+
+			const { result, rerender } = renderHook(
+				({ rows }) =>
+					useCallListPageActions({
+						applyCommand,
+						effectiveRows: rows,
+						selectedRows: [],
+						setSelectedRows,
+					}),
+				{ initialProps: { rows: [rowA] } },
+			);
+
+			// rowB is not in initial rows, so it should be dropped
+			act(() => {
+				result.current.handleSendToArchive([rowB.id], "Initial attempt");
+			});
+			expect(applyCommand).not.toHaveBeenCalled();
+
+			// Rerender with refreshed rows containing rowB
+			rerender({ rows: [rowA, rowB] });
+
+			act(() => {
+				result.current.handleSendToArchive([rowB.id], "After rerender");
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: rowB.id,
+					sourceStage: "call",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						archiveReason: "After rerender",
+					}),
+				}),
+			);
+		});
+	});
+
+	describe("builder delegation", () => {
+		it("explicitly delegates to real builder functions (buildReorderCommands, buildBookingCommands, buildSendToArchiveCommands) with expected arguments", async () => {
+			const row = createRow({
+				id: crypto.randomUUID(),
+			});
+			const onComplete = vi.fn();
+
+			const { result } = renderHook(() =>
+				useCallListPageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			// 1. buildReorderCommands delegation
+			await act(async () => {
+				await result.current.handleConfirmReorder("Defective part", onComplete);
+			});
+			expect(vi.mocked(buildReorderCommands)).toHaveBeenCalledWith(
+				[row],
+				"call",
+				"Defective part",
+			);
+
+			// 2. buildBookingCommands delegation
+			await act(async () => {
+				await result.current.handleConfirmBooking(
+					"2026-02-10",
+					"Customer confirmed",
+					"Confirmed",
+				);
+			});
+			expect(vi.mocked(buildBookingCommands)).toHaveBeenCalledWith(
+				[row],
+				"call",
+				"2026-02-10",
+				"Customer confirmed",
+				"Confirmed",
+			);
+
+			// 3. buildSendToArchiveCommands delegation
+			act(() => {
+				result.current.handleSendToArchive([row.id], "Customer cancelled");
+			});
+			expect(vi.mocked(buildSendToArchiveCommands)).toHaveBeenCalledWith(
+				[row],
+				"Customer cancelled",
+				"call",
+			);
+		});
+	});
+});


### PR DESCRIPTION
Closes #180.

Applies the four-part extraction shape established on Booking (#175–#178) to the Call List page, preserving every Call-List-specific behavior verbatim.

## What changed

| File | What |
|---|---|
| `src/app/(app)/call-list/useCallListPageActions.ts` (new) | Action-handler hook — mirrors `useBookingPageActions`. Params `{ applyCommand, effectiveRows, selectedRows, setSelectedRows }`. |
| `src/app/(app)/call-list/useCallListModals.ts` (new) | Modal-state hook — consolidates `isReorderModalOpen`/`reorderReason`, `isBookingModalOpen`, `showDeleteConfirm`. |
| `src/components/call-list/CallListToolbar.tsx` (new) | Presentational toolbar — JSX/classes/tooltips/disabled expressions copied byte-for-byte; `useColumnLayoutTracker("call-list")` moved inside. |
| `src/app/(app)/call-list/page.tsx` | Now a composition root: wires the three hooks/components + shared `ReorderReasonDialog`. Grid block, effects, draft session, repair-system filter logic, columns memo, `RowModals`, `ConfirmDialog` copy untouched. |
| `src/test/*` (4 new) | 35 tests: `useCallListPageActions` mirrors ticket 01 (behavioral vs. real builders + builder-delegation test with the module mocked); plus `useCallListModals`, `CallListToolbar`, and `ReorderReasonDialog`-adoption suites. |
| `FINDING_STAGE_EXTRACTION_REUSE.md` (new) | Reuse decision: keep hooks **stage-specific** (n=3 evidence), with a defined revisit trigger for Main Sheet & Archive. |

## Preserved verbatim (not normalized toward Booking)

- Empty-selection delete gate `handleDelete(onProceed)` with `toast.error("Please select at least one row")` — kept even though the button is also `disabled`.
- Toast copy: `"N row(s) sent to Booking"`, `"Row(s) deleted"`, `"N row(s) sent back to Orders (Reorder)"`.
- `buildBookingCommands` (send *to* Booking), not a rebooking builder. Stage literal `"call"`.
- Toolbar element order (Calendar → Reorder → Archive → `CallRepairSystemFilter`; right group `SelectAllByVinButton` → `CallCustomerCounter` → divider → Delete). Every gated button `disabled={selectedRows.length === 0}` only — no `draftDirty`/`hasMixedVins`. `CallCustomerCounter` not `VINLineCounter`.
- `ReorderReasonDialog` adopted with Call List's placeholder + helper text, no `srDescription` (page emits none today).

## Gates

- `pnpm type-check`: clean.
- Biome on changed files (what the pre-commit hook enforces): clean. Repo-wide `biome check .` has 364 pre-existing errors on `main`, unrelated.
- `pnpm test` (`vitest run`): 777 passed, 80 files (+35).
- `next build`: compiles + type-checks; fails only at the Windows `.next/standalone` symlink-copy step — the pre-existing env failure noted in #184.

## Review

Ran debate-review (main `claude` / debate `codex`) — verdict **Ship**, 0 P0/P1. One P2 docs finding: the decision record misdescribed Booking's rebooking guard and claimed `BookingCalendarModal` self-closes — both corrected in `4621a69`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyXANzrfdtFHkw89pgsDXr