### PR TITLE
refactor(main-sheet): adopt the extraction pattern (#181)

### DIFF
--- a/src/app/(app)/main-sheet/page.tsx
+++ b/src/app/(app)/main-sheet/page.tsx
@@ -3,7 +3,7 @@
 import type { GridApi } from "ag-grid-community";
 import { Unlock } from "lucide-react";
 import dynamic from "next/dynamic";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { DynamicDataGrid as DataGrid } from "@/components/grid";
 import { MainSheetToolbar } from "@/components/main-sheet/MainSheetToolbar";
@@ -24,38 +24,21 @@ const RowModals = dynamic(
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { getMainSheetColumns } from "@/components/shared/GridConfig";
 import { InfoLabel } from "@/components/shared/InfoLabel";
-import { Button } from "@/components/ui/button";
+import { ReorderReasonDialog } from "@/components/shared/ReorderReasonDialog";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-	Dialog,
-	DialogContent,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-	filterReservedRows,
-	getSelectedIds,
-	getVinAutoMoveIds,
-} from "@/domain/order/orderWorkflow";
+import { filterReservedRows } from "@/domain/order/orderWorkflow";
 import { useOrdersQuery } from "@/hooks/queries/useOrdersQuery";
 import { useDraftSession } from "@/hooks/useDraftSession";
 import { useRowModals } from "@/hooks/useRowModals";
 import { useSelectAllByVin } from "@/hooks/useSelectAllByVin";
 import { useSelectedRowsSync } from "@/hooks/useSelectedRowsSync";
-import {
-	buildBookingCommands,
-	buildReorderCommands,
-	buildSendToArchiveCommands,
-} from "@/lib/orderStageTransitions";
 import { printReservationLabels } from "@/lib/printing/reservationLabels";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
+import { useMainSheetModals } from "./useMainSheetModals";
+import { useMainSheetPageActions } from "./useMainSheetPageActions";
 
 export default function MainSheetPage() {
-	const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
 	const { data: rowData = [] } = useOrdersQuery("main");
 
 	// Draft session for undo/redo
@@ -78,34 +61,6 @@ export default function MainSheetPage() {
 
 	const partStatuses = useAppStore((state) => state.partStatuses);
 	const gridEditPermission = useAppStore((s) => s.gridEditPermission);
-
-	const handleUpdateOrder = useCallback(
-		(id: string, updates: Partial<PendingRow>) => {
-			applyCommand({
-				type: "patchRow",
-				id,
-				sourceStage: "main",
-				destinationStage: "main",
-				updates,
-				previousValues: {},
-			});
-			return Promise.resolve();
-		},
-		[applyCommand],
-	);
-
-	const handleSendToArchive = useCallback(
-		(ids: string[], reason: string) => {
-			const rows = ids.flatMap((id) => {
-				const row = effectiveRowData.find((r) => r.id === id);
-				return row ? [row] : [];
-			});
-			for (const cmd of buildSendToArchiveCommands(rows, reason, "main")) {
-				applyCommand(cmd);
-			}
-		},
-		[effectiveRowData, applyCommand],
-	);
 
 	const [isSheetLocked, setIsSheetLocked] = useState(true);
 	const [timeLeft, setTimeLeft] = useState(300); // 5 minutes in seconds
@@ -145,11 +100,23 @@ export default function MainSheetPage() {
 		selectedRows,
 		gridApi,
 	);
-	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+	const {
+		isReorderModalOpen,
+		setReorderModalOpen,
+		openReorder,
+		closeReorder,
+		reorderReason,
+		setReorderReason,
+		resetReorder,
+		isBookingModalOpen,
+		setBookingModalOpen,
+		openBooking,
+		showDeleteConfirm,
+		setShowDeleteConfirm,
+		openDeleteConfirm,
+	} = useMainSheetModals();
 	const [showFilters, setShowFilters] = useState(false);
 	const [activeFilter, setActiveFilter] = useState<string | null>(null);
-	const [isReorderModalOpen, setIsReorderModalOpen] = useState(false);
-	const [reorderReason, setReorderReason] = useState("");
 	const [scrollDir, setScrollDir] = useState<"vertical" | "horizontal">(
 		"vertical",
 	);
@@ -164,6 +131,21 @@ export default function MainSheetPage() {
 	// Sync selectedRows with the latest filteredRowData to prevent stale data
 	// and automatically drop rows that no longer match the active filter
 	useSelectedRowsSync("main", filteredRowData, selectedRows, setSelectedRows);
+
+	const {
+		handleUpdateOrder,
+		handleSendToArchive,
+		handleConfirmBooking,
+		handleConfirmReorder,
+		handleUpdatePartStatus,
+		handleSendToCallList,
+		handleConfirmDelete,
+	} = useMainSheetPageActions({
+		applyCommand,
+		effectiveRows: effectiveRowData,
+		selectedRows,
+		setSelectedRows,
+	});
 
 	const {
 		activeModal,
@@ -196,92 +178,6 @@ export default function MainSheetPage() {
 			isSheetLocked,
 		],
 	);
-
-	const handleUpdatePartStatus = async (status: string) => {
-		if (selectedRows.length === 0) return;
-
-		// 1. Apply patch commands for all status changes
-		for (const row of selectedRows) {
-			applyCommand({
-				type: "patchRow",
-				id: row.id,
-				sourceStage: "main",
-				destinationStage: "main",
-				updates: { status },
-				previousValues: { status: row.status },
-			});
-		}
-
-		// 2. Check each unique VIN for auto-move to Call List
-		const uniqueVins = [
-			...new Set(selectedRows.map((r) => r.vin).filter(Boolean)),
-		];
-
-		for (const vin of uniqueVins) {
-			// Use the first row edited for that VIN as the editedRowId
-			const editedRow = selectedRows.find((r) => r.vin === vin);
-			if (!editedRow) continue;
-
-			const vinIds = getVinAutoMoveIds({
-				stage: "main",
-				stageRows: effectiveRowData,
-				editedRowId: editedRow.id,
-				editedVin: vin,
-				nextStatus: status,
-			});
-
-			if (vinIds.length > 0) {
-				applyCommand({
-					type: "moveRows",
-					ids: vinIds,
-					sourceStage: "main",
-					destinationStage: "call",
-				});
-				toast.success(`All parts for VIN ${vin} arrived! Moved to Call List.`, {
-					duration: 5000,
-				});
-			}
-		}
-
-		toast.success(`Part status updated to "${status}"`);
-	};
-
-	const handleConfirmReorder = () => {
-		if (!reorderReason.trim()) {
-			toast.error("Please provide a reason for reorder");
-			return;
-		}
-		for (const cmd of buildReorderCommands(
-			selectedRows,
-			"main",
-			reorderReason,
-		)) {
-			applyCommand(cmd);
-		}
-		const count = selectedRows.length;
-		setSelectedRows([]);
-		setIsReorderModalOpen(false);
-		setReorderReason("");
-		toast.success(`${count} row(s) sent back to Orders (Reorder)`);
-	};
-
-	const handleConfirmBooking = async (
-		date: string,
-		note: string,
-		status?: string,
-	) => {
-		for (const cmd of buildBookingCommands(
-			selectedRows,
-			"main",
-			date,
-			note,
-			status,
-		)) {
-			applyCommand(cmd);
-		}
-		setSelectedRows([]);
-		toast.success(`${selectedRows.length} row(s) sent to Booking`);
-	};
 
 	return (
 		<>
@@ -320,7 +216,7 @@ export default function MainSheetPage() {
 							isSelectAllByVinDisabled={isSelectAllByVinDisabled}
 							onLockToggle={() => setIsSheetLocked(!isSheetLocked)}
 							onUpdateStatus={handleUpdatePartStatus}
-							onBooking={() => setIsBookingModalOpen(true)}
+							onBooking={openBooking}
 							onArchive={() => {
 								if (selectedRows.length > 0) {
 									handleArchiveClick(
@@ -329,20 +225,9 @@ export default function MainSheetPage() {
 									);
 								}
 							}}
-							onReorder={() => setIsReorderModalOpen(true)}
-							onSendToCallList={async () => {
-								if (selectedRows.length === 0) return;
-								const ids = getSelectedIds(selectedRows);
-								applyCommand({
-									type: "moveRows",
-									ids,
-									sourceStage: "main",
-									destinationStage: "call",
-								});
-								setSelectedRows([]);
-								toast.success(`${ids.length} item(s) sent to Call List`);
-							}}
-							onDelete={() => setShowDeleteConfirm(true)}
+							onReorder={openReorder}
+							onSendToCallList={handleSendToCallList}
+							onDelete={openDeleteConfirm}
 							onExtract={() => gridApi?.exportDataAsCsv()}
 							onFilterToggle={() => setShowFilters(!showFilters)}
 							onReserve={() => {
@@ -422,63 +307,26 @@ export default function MainSheetPage() {
 			{isBookingModalOpen && (
 				<BookingCalendarModal
 					open={isBookingModalOpen}
-					onOpenChange={setIsBookingModalOpen}
+					onOpenChange={setBookingModalOpen}
 					onConfirm={handleConfirmBooking}
 					selectedRows={selectedRows}
 				/>
 			)}
 
-			{/* Reorder Reason Modal */}
-			<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
-				<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
-					<DialogHeader>
-						<DialogTitle className="text-orange-500">
-							Reorder - Reason Required
-						</DialogTitle>
-					</DialogHeader>
-					<div className="space-y-4">
-						<div>
-							<Label>Reason for Reorder</Label>
-							<Input
-								value={reorderReason}
-								onChange={(e) => setReorderReason(e.target.value)}
-								placeholder="e.g., Customer called back, error on main sheet"
-								className="bg-white/5 border-white/10 text-white"
-							/>
-						</div>
-					</div>
-					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setIsReorderModalOpen(false)}
-							className="border-white/20 text-white hover:bg-white/10"
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="renault"
-							onClick={handleConfirmReorder}
-							disabled={!reorderReason.trim()}
-						>
-							Confirm Reorder
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<ReorderReasonDialog
+				open={isReorderModalOpen}
+				onOpenChange={setReorderModalOpen}
+				reason={reorderReason}
+				onReasonChange={setReorderReason}
+				onCancel={closeReorder}
+				onConfirm={() => handleConfirmReorder(reorderReason, resetReorder)}
+				placeholder="e.g., Customer called back, error on main sheet"
+			/>
 
 			<ConfirmDialog
 				open={showDeleteConfirm}
 				onOpenChange={setShowDeleteConfirm}
-				onConfirm={async () => {
-					const ids = getSelectedIds(selectedRows);
-					applyCommand({
-						type: "deleteRows",
-						ids,
-					});
-					setSelectedRows([]);
-					toast.success("Row(s) deleted");
-					setShowDeleteConfirm(false);
-				}}
+				onConfirm={handleConfirmDelete}
 				title="Delete Records"
 				description={`Are you sure you want to delete ${selectedRows.length} selected record(s)?`}
 				confirmText="Delete"

--- a/src/app/(app)/main-sheet/useMainSheetModals.ts
+++ b/src/app/(app)/main-sheet/useMainSheetModals.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+export function useMainSheetModals() {
+	const [isReorderModalOpen, setIsReorderModalOpen] = useState(false);
+	const [reorderReason, setReorderReason] = useState("");
+	const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+	return {
+		// reorder
+		isReorderModalOpen,
+		setReorderModalOpen: setIsReorderModalOpen,
+		openReorder: () => setIsReorderModalOpen(true),
+		closeReorder: () => setIsReorderModalOpen(false),
+		reorderReason,
+		setReorderReason,
+		resetReorder: () => {
+			setIsReorderModalOpen(false);
+			setReorderReason("");
+		},
+		// booking calendar modal
+		isBookingModalOpen,
+		setBookingModalOpen: setIsBookingModalOpen,
+		openBooking: () => setIsBookingModalOpen(true),
+		closeBooking: () => setIsBookingModalOpen(false),
+		// delete
+		showDeleteConfirm,
+		setShowDeleteConfirm,
+		openDeleteConfirm: () => setShowDeleteConfirm(true),
+		closeDeleteConfirm: () => setShowDeleteConfirm(false),
+	};
+}

--- a/src/app/(app)/main-sheet/useMainSheetPageActions.ts
+++ b/src/app/(app)/main-sheet/useMainSheetPageActions.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import type React from "react";
+import { useCallback } from "react";
+import { toast } from "sonner";
+import {
+	getSelectedIds,
+	getVinAutoMoveIds,
+} from "@/domain/order/orderWorkflow";
+import type { useDraftSession } from "@/hooks/useDraftSession";
+import {
+	buildBookingCommands,
+	buildReorderCommands,
+	buildSendToArchiveCommands,
+} from "@/lib/orderStageTransitions";
+import type { PendingRow } from "@/types";
+
+export function useMainSheetPageActions(params: {
+	applyCommand: ReturnType<typeof useDraftSession>["applyCommand"];
+	effectiveRows: PendingRow[];
+	selectedRows: PendingRow[];
+	setSelectedRows: React.Dispatch<React.SetStateAction<PendingRow[]>>;
+}) {
+	const { applyCommand, effectiveRows, selectedRows, setSelectedRows } = params;
+
+	const handleUpdateOrder = useCallback(
+		(id: string, updates: Partial<PendingRow>) => {
+			applyCommand({
+				type: "patchRow",
+				id,
+				sourceStage: "main",
+				destinationStage: "main",
+				updates,
+				previousValues: {},
+			});
+			return Promise.resolve();
+		},
+		[applyCommand],
+	);
+
+	const handleSendToArchive = useCallback(
+		(ids: string[], reason: string) => {
+			const rows = ids.flatMap((id) => {
+				const row = effectiveRows.find((r: PendingRow) => r.id === id);
+				return row ? [row] : [];
+			});
+			for (const cmd of buildSendToArchiveCommands(rows, reason, "main")) {
+				applyCommand(cmd);
+			}
+		},
+		[effectiveRows, applyCommand],
+	);
+
+	const handleConfirmBooking = async (
+		date: string,
+		note: string,
+		status?: string,
+	) => {
+		for (const cmd of buildBookingCommands(
+			selectedRows,
+			"main",
+			date,
+			note,
+			status,
+		)) {
+			applyCommand(cmd);
+		}
+		setSelectedRows([]);
+		toast.success(`${selectedRows.length} row(s) sent to Booking`);
+	};
+
+	const handleConfirmReorder = async (
+		reason: string,
+		onComplete: () => void,
+	) => {
+		if (!reason.trim()) {
+			toast.error("Please provide a reason for reorder");
+			return;
+		}
+		for (const cmd of buildReorderCommands(selectedRows, "main", reason)) {
+			applyCommand(cmd);
+		}
+		const count = selectedRows.length;
+		setSelectedRows([]);
+		onComplete();
+		toast.success(`${count} row(s) sent back to Orders (Reorder)`);
+	};
+
+	const handleSendToCallList = async () => {
+		if (selectedRows.length === 0) return;
+		const ids = getSelectedIds(selectedRows);
+		applyCommand({
+			type: "moveRows",
+			ids,
+			sourceStage: "main",
+			destinationStage: "call",
+		});
+		setSelectedRows([]);
+		toast.success(`${ids.length} item(s) sent to Call List`);
+	};
+
+	const handleConfirmDelete = async () => {
+		applyCommand({
+			type: "deleteRows",
+			ids: getSelectedIds(selectedRows),
+		});
+		setSelectedRows([]);
+		toast.success("Row(s) deleted");
+	};
+
+	const handleUpdatePartStatus = async (status: string) => {
+		if (selectedRows.length === 0) return;
+
+		// 1. Apply patch commands for all status changes
+		for (const row of selectedRows) {
+			applyCommand({
+				type: "patchRow",
+				id: row.id,
+				sourceStage: "main",
+				destinationStage: "main",
+				updates: { status },
+				previousValues: { status: row.status },
+			});
+		}
+
+		// 2. Check each unique VIN for auto-move to Call List
+		const uniqueVins = [
+			...new Set(selectedRows.map((r) => r.vin).filter(Boolean)),
+		];
+
+		for (const vin of uniqueVins) {
+			// Use the first row edited for that VIN as the editedRowId
+			const editedRow = selectedRows.find((r) => r.vin === vin);
+			if (!editedRow) continue;
+
+			const vinIds = getVinAutoMoveIds({
+				stage: "main",
+				stageRows: effectiveRows,
+				editedRowId: editedRow.id,
+				editedVin: vin,
+				nextStatus: status,
+			});
+
+			if (vinIds.length > 0) {
+				applyCommand({
+					type: "moveRows",
+					ids: vinIds,
+					sourceStage: "main",
+					destinationStage: "call",
+				});
+				toast.success(`All parts for VIN ${vin} arrived! Moved to Call List.`, {
+					duration: 5000,
+				});
+			}
+		}
+
+		toast.success(`Part status updated to "${status}"`);
+	};
+
+	return {
+		handleUpdateOrder,
+		handleSendToArchive,
+		handleConfirmBooking,
+		handleConfirmReorder,
+		handleUpdatePartStatus,
+		handleSendToCallList,
+		handleConfirmDelete,
+	};
+}

--- a/src/test/ReorderReasonDialogMainSheet.test.tsx
+++ b/src/test/ReorderReasonDialogMainSheet.test.tsx
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ReorderReasonDialog } from "@/components/shared/ReorderReasonDialog";
+
+vi.mock("@/components/ui/dialog", () => ({
+	Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+		open ? <div data-testid="reorder-dialog">{children}</div> : null,
+	DialogContent: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogHeader: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DialogTitle: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogDescription: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogFooter: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+describe("ReorderReasonDialog - Main Sheet adoption", () => {
+	const mainSheetProps = {
+		open: true,
+		onOpenChange: vi.fn(),
+		reason: "",
+		onReasonChange: vi.fn(),
+		onCancel: vi.fn(),
+		onConfirm: vi.fn(),
+		placeholder: "e.g., Customer called back, error on main sheet",
+	};
+
+	it("renders Main Sheet placeholder, does NOT render helperText, and does NOT render srDescription", () => {
+		const { container } = render(<ReorderReasonDialog {...mainSheetProps} />);
+
+		expect(
+			screen.getByPlaceholderText(
+				"e.g., Customer called back, error on main sheet",
+			),
+		).toBeInTheDocument();
+
+		// No helper text element rendered
+		const helperP = container.querySelector(".text-muted-foreground");
+		expect(helperP).toBeNull();
+
+		// No sr-only description element rendered
+		const srOnlyEl = container.querySelector(".sr-only");
+		expect(srOnlyEl).toBeNull();
+	});
+
+	it("keeps Confirm Reorder disabled when reason is blank, and enables it when filled", () => {
+		const { rerender } = render(
+			<ReorderReasonDialog {...mainSheetProps} reason="" />,
+		);
+
+		const confirmBtn = screen.getByRole("button", {
+			name: /confirm reorder/i,
+		});
+		expect(confirmBtn).toBeDisabled();
+
+		rerender(<ReorderReasonDialog {...mainSheetProps} reason="   " />);
+		expect(confirmBtn).toBeDisabled();
+
+		rerender(
+			<ReorderReasonDialog
+				{...mainSheetProps}
+				reason="Customer called back, error on main sheet"
+			/>,
+		);
+		expect(confirmBtn).toBeEnabled();
+	});
+
+	it("calls onConfirm when Confirm Reorder is clicked with non-empty reason", () => {
+		const onConfirm = vi.fn();
+		render(
+			<ReorderReasonDialog
+				{...mainSheetProps}
+				reason="Valid reason"
+				onConfirm={onConfirm}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /confirm reorder/i }));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		const onCancel = vi.fn();
+		render(<ReorderReasonDialog {...mainSheetProps} onCancel={onCancel} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/test/useMainSheetModals.test.ts
+++ b/src/test/useMainSheetModals.test.ts
@@ -1,0 +1,190 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useMainSheetModals } from "@/app/(app)/main-sheet/useMainSheetModals";
+
+describe("useMainSheetModals", () => {
+	it("initializes with all modals closed and an empty reorderReason", () => {
+		const { result } = renderHook(() => useMainSheetModals());
+
+		expect(result.current.isReorderModalOpen).toBe(false);
+		expect(result.current.reorderReason).toBe("");
+		expect(result.current.isBookingModalOpen).toBe(false);
+		expect(result.current.showDeleteConfirm).toBe(false);
+	});
+
+	describe("reorder modal", () => {
+		it("openReorder() opens modal; closeReorder() closes it and leaves reorderReason unchanged", () => {
+			const { result } = renderHook(() => useMainSheetModals());
+
+			act(() => {
+				result.current.setReorderReason("Wrong part supplied");
+			});
+			expect(result.current.reorderReason).toBe("Wrong part supplied");
+
+			act(() => {
+				result.current.openReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+
+			act(() => {
+				result.current.closeReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("Wrong part supplied");
+		});
+
+		it("resetReorder() closes modal and clears reorderReason to empty string", () => {
+			const { result } = renderHook(() => useMainSheetModals());
+
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Customer cancelled");
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.reorderReason).toBe("Customer cancelled");
+
+			act(() => {
+				result.current.resetReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("");
+		});
+
+		it("setReorderModalOpen(false) (the onOpenChange path) closes without clearing a set reason", () => {
+			const { result } = renderHook(() => useMainSheetModals());
+
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Part defective");
+			});
+
+			act(() => {
+				result.current.setReorderModalOpen(false);
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("Part defective");
+
+			act(() => {
+				result.current.setReorderModalOpen(true);
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.reorderReason).toBe("Part defective");
+		});
+	});
+
+	describe("booking calendar modal", () => {
+		it("openBooking() and closeBooking() toggle isBookingModalOpen only", () => {
+			const { result } = renderHook(() => useMainSheetModals());
+
+			act(() => {
+				result.current.openBooking();
+			});
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+
+			act(() => {
+				result.current.closeBooking();
+			});
+			expect(result.current.isBookingModalOpen).toBe(false);
+		});
+
+		it("setBookingModalOpen() directly controls isBookingModalOpen for onOpenChange", () => {
+			const { result } = renderHook(() => useMainSheetModals());
+
+			act(() => {
+				result.current.setBookingModalOpen(true);
+			});
+			expect(result.current.isBookingModalOpen).toBe(true);
+
+			act(() => {
+				result.current.setBookingModalOpen(false);
+			});
+			expect(result.current.isBookingModalOpen).toBe(false);
+		});
+	});
+
+	describe("delete confirm modal", () => {
+		it("openDeleteConfirm() and closeDeleteConfirm() toggle showDeleteConfirm only", () => {
+			const { result } = renderHook(() => useMainSheetModals());
+
+			act(() => {
+				result.current.openDeleteConfirm();
+			});
+			expect(result.current.showDeleteConfirm).toBe(true);
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.isBookingModalOpen).toBe(false);
+
+			act(() => {
+				result.current.closeDeleteConfirm();
+			});
+			expect(result.current.showDeleteConfirm).toBe(false);
+		});
+
+		it("setShowDeleteConfirm() directly controls showDeleteConfirm for onOpenChange", () => {
+			const { result } = renderHook(() => useMainSheetModals());
+
+			act(() => {
+				result.current.setShowDeleteConfirm(true);
+			});
+			expect(result.current.showDeleteConfirm).toBe(true);
+
+			act(() => {
+				result.current.setShowDeleteConfirm(false);
+			});
+			expect(result.current.showDeleteConfirm).toBe(false);
+		});
+	});
+
+	describe("cross-independence", () => {
+		it("opening one modal does not change the other modals or mutate state unexpectedly", () => {
+			const { result } = renderHook(() => useMainSheetModals());
+
+			// Open reorder
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Test reason");
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+
+			// Open booking
+			act(() => {
+				result.current.openBooking();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Open delete confirm
+			act(() => {
+				result.current.openDeleteConfirm();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.showDeleteConfirm).toBe(true);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Close booking & delete confirm - reorder remains open with reason intact
+			act(() => {
+				result.current.closeBooking();
+				result.current.closeDeleteConfirm();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Reset reorder clears reason and closes reorder modal
+			act(() => {
+				result.current.resetReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("");
+		});
+	});
+});

--- a/src/test/useMainSheetPageActions.test.ts
+++ b/src/test/useMainSheetPageActions.test.ts
@@ -1,0 +1,707 @@
+import { act, renderHook } from "@testing-library/react";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useMainSheetPageActions } from "@/app/(app)/main-sheet/useMainSheetPageActions";
+import {
+	buildBookingCommands,
+	buildReorderCommands,
+	buildSendToArchiveCommands,
+} from "@/lib/orderStageTransitions";
+import type { PendingRow } from "@/types";
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock("@/lib/orderStageTransitions", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/orderStageTransitions")>();
+	return {
+		...actual,
+		buildReorderCommands: vi.fn(actual.buildReorderCommands),
+		buildBookingCommands: vi.fn(actual.buildBookingCommands),
+		buildSendToArchiveCommands: vi.fn(actual.buildSendToArchiveCommands),
+	};
+});
+
+const createRow = (overrides: Partial<PendingRow> = {}): PendingRow => ({
+	id: crypto.randomUUID(),
+	baseId: "B1",
+	trackingId: "T1",
+	customerName: "Test Customer",
+	mobile: "123456789",
+	parts: [],
+	status: "Pending",
+	rDate: "2024-01-01",
+	requester: "Admin",
+	acceptedBy: "Admin",
+	sabNumber: "S1",
+	model: "Clio",
+	cntrRdg: 1000,
+	repairSystem: "None",
+	startWarranty: "",
+	endWarranty: "",
+	remainTime: "",
+	partNumber: "P1",
+	description: "Test Part",
+	quantity: 1,
+	vin: "VF1BB0A0F12345678",
+	stage: "main",
+	...overrides,
+});
+
+describe("useMainSheetPageActions", () => {
+	const applyCommand = vi.fn();
+	const setSelectedRows = vi.fn();
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+		vi.clearAllMocks();
+		applyCommand.mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("handleConfirmReorder", () => {
+		it("rejects reorder when reason is empty or whitespace-only without calling applyCommand, setSelectedRows, or onComplete", async () => {
+			const row = createRow();
+			const onComplete = vi.fn();
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("", onComplete);
+			});
+
+			expect(toast.error).toHaveBeenCalledWith(
+				"Please provide a reason for reorder",
+			);
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(setSelectedRows).not.toHaveBeenCalled();
+			expect(onComplete).not.toHaveBeenCalled();
+
+			vi.clearAllMocks();
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("   ", onComplete);
+			});
+
+			expect(toast.error).toHaveBeenCalledWith(
+				"Please provide a reason for reorder",
+			);
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(setSelectedRows).not.toHaveBeenCalled();
+			expect(onComplete).not.toHaveBeenCalled();
+		});
+
+		it("reorders rows individually, clears selection, calls onComplete, and toasts with correct order", async () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const selected = [row1, row2];
+			const onComplete = vi.fn();
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("Damaged item", onComplete);
+			});
+
+			expect(buildReorderCommands).toHaveBeenCalledTimes(1);
+			expect(buildReorderCommands).toHaveBeenCalledWith(
+				selected,
+				"main",
+				"Damaged item",
+			);
+
+			expect(applyCommand).toHaveBeenCalledTimes(selected.length);
+			for (const call of applyCommand.mock.calls) {
+				expect(call[0]).toMatchObject({
+					type: "patchRow",
+					sourceStage: "main",
+					destinationStage: "orders",
+				});
+			}
+
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(onComplete).toHaveBeenCalledTimes(1);
+			expect(toast.success).toHaveBeenCalledWith(
+				"2 row(s) sent back to Orders (Reorder)",
+			);
+
+			// Preserved order: applyCommand -> setSelectedRows -> onComplete -> toast.success
+			const lastApply = Math.max(...applyCommand.mock.invocationCallOrder);
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const complete = onComplete.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(lastApply).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(complete);
+			expect(complete).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleConfirmBooking", () => {
+		it("replays buildBookingCommands output, clears selection, and toasts success", async () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmBooking(
+					"2026-02-15",
+					"Customer requested booking",
+					"Confirmed",
+				);
+			});
+
+			expect(buildBookingCommands).toHaveBeenCalledTimes(1);
+			expect(buildBookingCommands).toHaveBeenCalledWith(
+				selected,
+				"main",
+				"2026-02-15",
+				"Customer requested booking",
+				"Confirmed",
+			);
+
+			expect(applyCommand).toHaveBeenCalledTimes(selected.length);
+			for (const call of applyCommand.mock.calls) {
+				expect(call[0]).toMatchObject({
+					type: "patchRow",
+					sourceStage: "main",
+					destinationStage: "booking",
+				});
+			}
+
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(toast.success).toHaveBeenCalledWith("2 row(s) sent to Booking");
+
+			const lastApply = Math.max(...applyCommand.mock.invocationCallOrder);
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(lastApply).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleSendToCallList", () => {
+		it("no-ops when selectedRows is empty", async () => {
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: [],
+					selectedRows: [],
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleSendToCallList();
+			});
+
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(setSelectedRows).not.toHaveBeenCalled();
+			expect(toast.success).not.toHaveBeenCalled();
+		});
+
+		it("moves selected rows to call list, clears selection, and toasts success", async () => {
+			const uuid1 = crypto.randomUUID();
+			const uuid2 = crypto.randomUUID();
+			const row1 = createRow({ id: uuid1 });
+			const row2 = createRow({ id: uuid2 });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleSendToCallList();
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith({
+				type: "moveRows",
+				ids: [uuid1, uuid2],
+				sourceStage: "main",
+				destinationStage: "call",
+			});
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(toast.success).toHaveBeenCalledWith("2 item(s) sent to Call List");
+
+			// Preserved order: applyCommand -> setSelectedRows -> toast.success
+			const applyOrder = applyCommand.mock.invocationCallOrder[0];
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(applyOrder).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleConfirmDelete", () => {
+		it("deletes selected rows in a single batch, clears selection, and toasts", async () => {
+			const uuid1 = crypto.randomUUID();
+			const uuid2 = crypto.randomUUID();
+			const row1 = createRow({ id: uuid1 });
+			const row2 = createRow({ id: uuid2 });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmDelete();
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith({
+				type: "deleteRows",
+				ids: [uuid1, uuid2],
+			});
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(toast.success).toHaveBeenCalledWith("Row(s) deleted");
+
+			// Preserved order: applyCommand -> setSelectedRows -> toast.success
+			const applyOrder = applyCommand.mock.invocationCallOrder[0];
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(applyOrder).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleUpdateOrder", () => {
+		it("dispatches patchRow command targeting main stage and resolves", async () => {
+			const row = createRow();
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			let resolvedValue: unknown;
+			await act(async () => {
+				resolvedValue = await result.current.handleUpdateOrder(row.id, {
+					customerName: "New Name",
+				});
+			});
+
+			expect(resolvedValue).toBeUndefined();
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith({
+				type: "patchRow",
+				id: row.id,
+				sourceStage: "main",
+				destinationStage: "main",
+				updates: { customerName: "New Name" },
+				previousValues: {},
+			});
+		});
+	});
+
+	describe("handleSendToArchive", () => {
+		it("preserves ID ordering and silently drops unknown IDs when archiving", () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const row3 = createRow({ id: crypto.randomUUID() });
+			const unknownId = crypto.randomUUID();
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: [row1, row2, row3],
+					selectedRows: [],
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleSendToArchive(
+					[row3.id, unknownId, row1.id],
+					"Scrapped",
+				);
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(2);
+			expect(applyCommand).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining({
+					id: row3.id,
+					sourceStage: "main",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						status: "Archived",
+						archiveReason: "Scrapped",
+						archivedAt: "2026-01-01T00:00:00.000Z",
+					}),
+				}),
+			);
+			expect(applyCommand).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					id: row1.id,
+					sourceStage: "main",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						status: "Archived",
+						archiveReason: "Scrapped",
+						archivedAt: "2026-01-01T00:00:00.000Z",
+					}),
+				}),
+			);
+		});
+
+		it("resolves rows from refreshed effectiveRows after rerender", () => {
+			const rowA = createRow({ id: crypto.randomUUID() });
+			const rowB = createRow({ id: crypto.randomUUID() });
+
+			const { result, rerender } = renderHook(
+				({ rows }) =>
+					useMainSheetPageActions({
+						applyCommand,
+						effectiveRows: rows,
+						selectedRows: [],
+						setSelectedRows,
+					}),
+				{ initialProps: { rows: [rowA] } },
+			);
+
+			// rowB is not in initial rows, so it should be dropped
+			act(() => {
+				result.current.handleSendToArchive([rowB.id], "Initial attempt");
+			});
+			expect(applyCommand).not.toHaveBeenCalled();
+
+			// Rerender with refreshed rows containing rowB
+			rerender({ rows: [rowA, rowB] });
+
+			act(() => {
+				result.current.handleSendToArchive([rowB.id], "After rerender");
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: rowB.id,
+					sourceStage: "main",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						archiveReason: "After rerender",
+					}),
+				}),
+			);
+		});
+	});
+
+	describe("handleUpdatePartStatus", () => {
+		it("no-ops when selectedRows is empty", async () => {
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: [],
+					selectedRows: [],
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleUpdatePartStatus("Reserve");
+			});
+
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(toast.success).not.toHaveBeenCalled();
+		});
+
+		it("updates part status with previousValues containing each row's previous status and no moveRows when VIN arrival is not triggered", async () => {
+			const row1 = createRow({
+				id: crypto.randomUUID(),
+				status: "Pending",
+				vin: "VF1BB0A0F12345671",
+			});
+			const row2 = createRow({
+				id: crypto.randomUUID(),
+				status: "Ordered",
+				vin: "VF1BB0A0F12345672",
+			});
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleUpdatePartStatus("Reserve");
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(2);
+			expect(applyCommand).toHaveBeenNthCalledWith(1, {
+				type: "patchRow",
+				id: row1.id,
+				sourceStage: "main",
+				destinationStage: "main",
+				updates: { status: "Reserve" },
+				previousValues: { status: "Pending" },
+			});
+			expect(applyCommand).toHaveBeenNthCalledWith(2, {
+				type: "patchRow",
+				id: row2.id,
+				sourceStage: "main",
+				destinationStage: "main",
+				updates: { status: "Reserve" },
+				previousValues: { status: "Ordered" },
+			});
+
+			// No moveRows command
+			for (const call of applyCommand.mock.calls) {
+				expect(call[0].type).toBe("patchRow");
+			}
+
+			expect(toast.success).toHaveBeenCalledTimes(1);
+			expect(toast.success).toHaveBeenCalledWith(
+				'Part status updated to "Reserve"',
+			);
+		});
+
+		it("triggers VIN auto-move to Call List when all parts for a VIN reach Arrived status", async () => {
+			const vin = "VF1BB0A0F12345678";
+			const uuid1 = crypto.randomUUID();
+			const uuid2 = crypto.randomUUID();
+
+			// row1 already arrived in main stage
+			const row1 = createRow({
+				id: uuid1,
+				vin,
+				stage: "main",
+				status: "Arrived",
+			});
+			// row2 is currently pending in main stage and will be updated to Arrived
+			const row2 = createRow({
+				id: uuid2,
+				vin,
+				stage: "main",
+				status: "Pending",
+			});
+
+			const effectiveRows = [row1, row2];
+			const selectedRows = [row2];
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows,
+					selectedRows,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleUpdatePartStatus("Arrived");
+			});
+
+			// 1. patchRow command for row2
+			expect(applyCommand).toHaveBeenNthCalledWith(1, {
+				type: "patchRow",
+				id: uuid2,
+				sourceStage: "main",
+				destinationStage: "main",
+				updates: { status: "Arrived" },
+				previousValues: { status: "Pending" },
+			});
+
+			// 2. moveRows command for all rows of the completed VIN
+			expect(applyCommand).toHaveBeenNthCalledWith(2, {
+				type: "moveRows",
+				ids: [uuid1, uuid2],
+				sourceStage: "main",
+				destinationStage: "call",
+			});
+
+			// 3. Per-VIN toast with duration 5000
+			expect(toast.success).toHaveBeenNthCalledWith(
+				1,
+				`All parts for VIN ${vin} arrived! Moved to Call List.`,
+				{ duration: 5000 },
+			);
+
+			// 4. Final toast
+			expect(toast.success).toHaveBeenNthCalledWith(
+				2,
+				'Part status updated to "Arrived"',
+			);
+
+			// Invocation order: patchRow -> moveRows -> per-VIN toast -> final toast
+			const patchOrder = applyCommand.mock.invocationCallOrder[0];
+			const moveOrder = applyCommand.mock.invocationCallOrder[1];
+			const vinToastOrder = vi.mocked(toast.success).mock
+				.invocationCallOrder[0];
+			const finalToastOrder = vi.mocked(toast.success).mock
+				.invocationCallOrder[1];
+
+			expect(patchOrder).toBeLessThan(moveOrder);
+			expect(moveOrder).toBeLessThan(vinToastOrder);
+			expect(vinToastOrder).toBeLessThan(finalToastOrder);
+		});
+
+		it("does not auto-move if some parts for the VIN remain non-arrived", async () => {
+			const vin = "VF1BB0A0F12345678";
+			const uuid1 = crypto.randomUUID();
+			const uuid2 = crypto.randomUUID();
+			const uuid3 = crypto.randomUUID();
+
+			// row1 and row2 are pending, row3 is pending
+			const row1 = createRow({
+				id: uuid1,
+				vin,
+				stage: "main",
+				status: "Pending",
+			});
+			const row2 = createRow({
+				id: uuid2,
+				vin,
+				stage: "main",
+				status: "Pending",
+			});
+			const row3 = createRow({
+				id: uuid3,
+				vin,
+				stage: "main",
+				status: "Pending",
+			});
+
+			const effectiveRows = [row1, row2, row3];
+			// Only row1 is selected to be marked Arrived, leaving row2 and row3 Pending
+			const selectedRows = [row1];
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows,
+					selectedRows,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleUpdatePartStatus("Arrived");
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith({
+				type: "patchRow",
+				id: uuid1,
+				sourceStage: "main",
+				destinationStage: "main",
+				updates: { status: "Arrived" },
+				previousValues: { status: "Pending" },
+			});
+
+			expect(toast.success).toHaveBeenCalledTimes(1);
+			expect(toast.success).toHaveBeenCalledWith(
+				'Part status updated to "Arrived"',
+			);
+		});
+	});
+
+	describe("builder delegation", () => {
+		it("explicitly delegates to real builder functions (buildReorderCommands, buildBookingCommands, buildSendToArchiveCommands) with expected arguments", async () => {
+			const row = createRow({
+				id: crypto.randomUUID(),
+			});
+			const onComplete = vi.fn();
+
+			const { result } = renderHook(() =>
+				useMainSheetPageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			// 1. buildReorderCommands delegation
+			await act(async () => {
+				await result.current.handleConfirmReorder("Defective part", onComplete);
+			});
+			expect(vi.mocked(buildReorderCommands)).toHaveBeenCalledWith(
+				[row],
+				"main",
+				"Defective part",
+			);
+
+			// 2. buildBookingCommands delegation
+			await act(async () => {
+				await result.current.handleConfirmBooking(
+					"2026-02-10",
+					"Customer confirmed",
+					"Confirmed",
+				);
+			});
+			expect(vi.mocked(buildBookingCommands)).toHaveBeenCalledWith(
+				[row],
+				"main",
+				"2026-02-10",
+				"Customer confirmed",
+				"Confirmed",
+			);
+
+			// 3. buildSendToArchiveCommands delegation
+			act(() => {
+				result.current.handleSendToArchive([row.id], "Customer cancelled");
+			});
+			expect(vi.mocked(buildSendToArchiveCommands)).toHaveBeenCalledWith(
+				[row],
+				"Customer cancelled",
+				"main",
+			);
+		});
+	});
+});


### PR DESCRIPTION
Closes #181.

Applies the four-part extraction shape (Booking #175–#178, Call List #180) to the Main Sheet page. **Pure structural refactor — no behavior or UI change.**

## Changes

| File | |
|---|---|
| `src/app/(app)/main-sheet/useMainSheetPageActions.ts` | **new** — action-handler hook, params `{ applyCommand, effectiveRows, selectedRows, setSelectedRows }`, mirroring `useCallListPageActions` |
| `src/app/(app)/main-sheet/useMainSheetModals.ts` | **new** — modal-state hook, mirrors `useCallListModals` |
| `src/app/(app)/main-sheet/page.tsx` | wire both hooks; inline reorder `<Dialog>` → shared `<ReorderReasonDialog>`; `MainSheetToolbar` props re-pointed to hook handlers with no structural change |
| `src/test/useMainSheetPageActions.test.ts` | **new** — 27 tests, mirrors #180's delegation-proving approach |
| `src/test/useMainSheetModals.test.ts` | **new** |
| `src/test/ReorderReasonDialogMainSheet.test.tsx` | **new** |

## Main-Sheet-specific behavior preserved verbatim

- **`handleUpdatePartStatus` is NOT generalized.** It still captures `previousValues: { status: row.status }` (not `{}`), evaluates VIN groups via the real `getVinAutoMoveIds`, dispatches automatic `moveRows` → Call List, and fires the `All parts for VIN … arrived! Moved to Call List.` toast with `{ duration: 5000 }`, then the final `Part status updated to "<status>"` toast.
- `handleConfirmReorder` adopts Call List's `(reason, onComplete)` signature — the modal close + reason clear now run via `resetReorder` passed as `onComplete`. Same order, same strings.
- `handleConfirmDelete` drops the redundant `setShowDeleteConfirm(false)` — the shared `ConfirmDialog` calls `onOpenChange(false)` itself.
- `handleSendToCallList` extracted from the inline toolbar prop, unchanged.
- `ReorderReasonDialog` gets Main Sheet's exact placeholder; **no** `helperText`/`srDescription` passed, so the rendered DOM matches the previous inline `Dialog` exactly.
- `MainSheetToolbar` already owns `useColumnLayoutTracker("main-sheet")` — no toolbar extraction needed (per the issue).
- Page keeps its own concerns: sheet lock + 5-min auto-lock timer, `activeFilter`/`filteredRowData`, `showFilters`, `scrollDir`, `gridApi`, `selectedRows`.

## Tests

`useMainSheetPageActions.test.ts` mirrors ticket 01: behavioral assertions against the **real** builders plus a builder-delegation test with `@/lib/orderStageTransitions` mocked. A dedicated `handleUpdatePartStatus` block proves the `previousValues:{status}` capture and the VIN auto-move using the real `getVinAutoMoveIds` (positive, partial-arrival negative, and previous-status cases).

## Gates

- `biome check` — clean on all changed files
- `pnpm type-check` — clean
- `pnpm test` — **804 passed (83 files)**, +27 new
- `next build` — compiles + type-checks; fails only at the Windows standalone symlink-copy step (pre-existing env failure, #184/#188)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUDrCUMEviY2YEA89icAjq