### PR TITLE
refactor(archive): adopt the extraction pattern (#182)

### DIFF
--- a/FINDING_STAGE_EXTRACTION_REUSE.md
+++ b/FINDING_STAGE_EXTRACTION_REUSE.md
@@ -95,3 +95,7 @@ action-handler hook **and** all four hooks turn out to differ only by:
 i.e. the builder set, the completion ordering, and the `onComplete`/guard shape are the same across
 all four. Track those three axes explicitly when implementing Main Sheet and Archive. If they still
 diverge at n=4, stay stage-specific permanently.
+
+## n=4 — Archive (#182) resolution
+
+Archive is the fourth and final stage to adopt the four-part extraction shape (action-handler hook `useArchivePageActions`, modal-state hook `useArchiveModals`, `ArchiveToolbar` component, and the shared `ReorderReasonDialog`). It is the fifth workflow stage but the fourth adopter — Orders predates the pattern (`useOrdersPageHandlers`, ~525 LOC). Checking the revisit trigger: the hooks still diverge across all four stages — Archive keeps its own delete toast `"Archived record(s) deleted"` (vs. `"Row(s) deleted"` in Call List / Main Sheet), its own `ConfirmDialog` copy with `title="Delete Archived Records"` and `confirmText="Permanently Delete"`, and has no empty-selection `handleDelete` gate (the delete button is guarded solely by `disabled={selectedRows.length === 0}`). Because the builder set, toast copy, and guard shape continue to differ across all four hooks, the decision per the revisit trigger is: **stay stage-specific permanently**. No shared generic hook will be introduced.

--- a/src/app/(app)/archive/page.tsx
+++ b/src/app/(app)/archive/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import type {
 	CellStyle,
@@ -6,65 +6,26 @@ import type {
 	ValueFormatterParams,
 } from "ag-grid-community";
 import { format } from "date-fns";
-import {
-	Calendar,
-	CheckCircle,
-	Download,
-	Filter,
-	RotateCcw,
-	Trash2,
-} from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { useEffect, useMemo, useState } from "react";
+import { ArchiveToolbar } from "@/components/archive/ArchiveToolbar";
 import { DynamicDataGrid as DataGrid } from "@/components/grid";
 import { BookingCalendarModal } from "@/components/shared/BookingCalendarModal";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { getBaseColumns } from "@/components/shared/GridConfig";
 import { InfoLabel } from "@/components/shared/InfoLabel";
-import { LayoutSaveButton } from "@/components/shared/LayoutSaveButton";
+import { ReorderReasonDialog } from "@/components/shared/ReorderReasonDialog";
 import { RowModals } from "@/components/shared/RowModals";
-import { SelectAllByVinButton } from "@/components/shared/SelectAllByVinButton";
-import { VINLineCounter } from "@/components/shared/VINLineCounter";
-import { Button } from "@/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { getSelectedIds } from "@/domain/order/orderWorkflow";
 import { useOrdersQuery } from "@/hooks/queries/useOrdersQuery";
-import { useColumnLayoutTracker } from "@/hooks/useColumnLayoutTracker";
 import { useDraftSession } from "@/hooks/useDraftSession";
 import { useRowModals } from "@/hooks/useRowModals";
 import { useSelectAllByVin } from "@/hooks/useSelectAllByVin";
 import { useSelectedRowsSync } from "@/hooks/useSelectedRowsSync";
-import {
-	buildBookingCommands,
-	buildReorderCommands,
-	buildSendToArchiveCommands,
-} from "@/lib/orderStageTransitions";
-import { cn } from "@/lib/utils";
 import { useAppStore } from "@/store/useStore";
 import type { PendingRow } from "@/types";
+import { useArchiveModals } from "./useArchiveModals";
+import { useArchivePageActions } from "./useArchivePageActions";
 
 export default function ArchivePage() {
-	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
-		useColumnLayoutTracker("archive");
 	const { data: archiveRowData = [] } = useOrdersQuery("archive");
 
 	// Draft session for undo/redo
@@ -88,33 +49,6 @@ export default function ArchivePage() {
 	const partStatuses = useAppStore((state) => state.partStatuses);
 	const gridEditPermission = useAppStore((s) => s.gridEditPermission);
 
-	const handleUpdateOrder = useCallback(
-		(id: string, updates: Partial<PendingRow>) => {
-			applyCommand({
-				type: "patchRow",
-				id,
-				sourceStage: "archive",
-				destinationStage: "archive",
-				updates,
-				previousValues: {},
-			});
-			return Promise.resolve();
-		},
-		[applyCommand],
-	);
-
-	const handleSendToArchive = useCallback(
-		(ids: string[], reason: string) => {
-			const rows = ids.flatMap((id) => {
-				const row = effectiveData.find((r) => r.id === id);
-				return row ? [row] : [];
-			});
-			for (const cmd of buildSendToArchiveCommands(rows, reason, "archive")) {
-				applyCommand(cmd);
-			}
-		},
-		[effectiveData, applyCommand],
-	);
 	const [gridApi, setGridApi] = useState<GridApi | null>(null);
 	const [selectedRows, setSelectedRows] = useState<PendingRow[]>([]);
 
@@ -122,14 +56,41 @@ export default function ArchivePage() {
 		selectedRows,
 		gridApi,
 	);
-	const [isReorderModalOpen, setIsReorderModalOpen] = useState(false);
-	const [reorderReason, setReorderReason] = useState("");
-	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
 	const [showFilters, setShowFilters] = useState(false);
-	const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
 	const [scrollDir, setScrollDir] = useState<"vertical" | "horizontal">(
 		"vertical",
 	);
+
+	const {
+		isReorderModalOpen,
+		setReorderModalOpen,
+		openReorder,
+		closeReorder,
+		reorderReason,
+		setReorderReason,
+		resetReorder,
+		isBookingModalOpen,
+		setBookingModalOpen,
+		openBooking,
+		showDeleteConfirm,
+		setShowDeleteConfirm,
+		openDeleteConfirm,
+	} = useArchiveModals();
+
+	const {
+		handleUpdateOrder,
+		handleSendToArchive,
+		handleConfirmBooking,
+		handleConfirmReorder,
+		handleUpdatePartStatus,
+		handleConfirmDelete,
+	} = useArchivePageActions({
+		applyCommand,
+		effectiveRows: effectiveData,
+		selectedRows,
+		setSelectedRows,
+	});
 
 	// Sync selectedRows with the latest effectiveData to prevent stale data
 	useSelectedRowsSync("archive", effectiveData, selectedRows, setSelectedRows);
@@ -145,52 +106,6 @@ export default function ArchivePage() {
 		saveReminder,
 		saveAttachment,
 	} = useRowModals(handleUpdateOrder, handleSendToArchive);
-
-	const handleConfirmReorder = async () => {
-		if (!reorderReason.trim()) {
-			toast.error("Please provide a reason for reorder");
-			return;
-		}
-		for (const cmd of buildReorderCommands(
-			selectedRows,
-			"archive",
-			reorderReason,
-		)) {
-			applyCommand(cmd);
-		}
-		setSelectedRows([]);
-		setIsReorderModalOpen(false);
-		setReorderReason("");
-		toast.success(
-			`${selectedRows.length} row(s) sent back to Orders (Reorder)`,
-		);
-	};
-
-	const handleUpdatePartStatus = (status: string) => {
-		if (selectedRows.length === 0) return;
-		selectedRows.forEach((row) => {
-			handleUpdateOrder(row.id, { status });
-		});
-		toast.success(`Updated ${selectedRows.length} item(s) to ${status}`);
-	};
-
-	const handleConfirmBooking = async (
-		date: string,
-		note: string,
-		status?: string,
-	) => {
-		for (const cmd of buildBookingCommands(
-			selectedRows,
-			"archive",
-			date,
-			note,
-			status,
-		)) {
-			applyCommand(cmd);
-		}
-		setSelectedRows([]);
-		toast.success(`${selectedRows.length} row(s) sent to Booking`);
-	};
 
 	const columns = useMemo(() => {
 		const baseColumns = getBaseColumns(
@@ -230,144 +145,19 @@ export default function ArchivePage() {
 		<div className="space-y-4 h-full flex flex-col">
 			<InfoLabel data={selectedRows[0] || null} />
 
-			<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
-				<div className="flex items-center gap-1.5">
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
-								onClick={() => gridApi?.exportDataAsCsv()}
-							>
-								<Download className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Extract</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-gray-400 hover:text-white h-8 w-8"
-								onClick={() => setShowFilters(!showFilters)}
-							>
-								<Filter className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Filter</TooltipContent>
-					</Tooltip>
-
-					<LayoutSaveButton
-						isDirty={isDirty}
-						isPositionDirty={isPositionDirty}
-						onSave={saveLayout}
-						onSaveAsDefault={saveAsDefault}
-						onReset={resetLayout}
-					/>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon"
-										className="text-gray-400 hover:text-white h-8 w-8"
-										disabled={selectedRows.length === 0}
-									>
-										<CheckCircle className="h-4 w-4" />
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent
-									align="end"
-									className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
-								>
-									{partStatuses?.map((status) => {
-										const isHex =
-											status.color?.startsWith("#") ||
-											status.color?.startsWith("rgb");
-										const dotStyle = isHex
-											? { backgroundColor: status.color }
-											: undefined;
-										const colorClass = isHex ? "" : status.color;
-
-										return (
-											<DropdownMenuItem
-												key={status.id}
-												onClick={() => handleUpdatePartStatus(status.label)}
-												className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
-											>
-												<div
-													className={cn("w-2 h-2 rounded-full", colorClass)}
-													style={dotStyle}
-												/>
-												<span className="text-xs">{status.label}</span>
-											</DropdownMenuItem>
-										);
-									})}
-								</DropdownMenuContent>
-							</DropdownMenu>
-						</TooltipTrigger>
-						<TooltipContent>Update Status</TooltipContent>
-					</Tooltip>
-
-					<div className="w-px h-5 bg-white/10 mx-1" />
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
-								onClick={() => setIsReorderModalOpen(true)}
-								disabled={selectedRows.length === 0}
-							>
-								<RotateCcw className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Reorder</TooltipContent>
-					</Tooltip>
-
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-green-500/80 hover:text-green-500 h-8 w-8"
-								onClick={() => setIsBookingModalOpen(true)}
-								disabled={selectedRows.length === 0}
-							>
-								<Calendar className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Reschedule Booking</TooltipContent>
-					</Tooltip>
-				</div>
-
-				<div className="flex items-center gap-1.5">
-					<SelectAllByVinButton
-						onSelectAllByVin={onSelectAllByVin}
-						isDisabled={isSelectAllByVinDisabled}
-					/>
-					<VINLineCounter rows={effectiveData} />
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								size="icon"
-								variant="ghost"
-								className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
-								onClick={() => setShowDeleteConfirm(true)}
-								disabled={selectedRows.length === 0}
-							>
-								<Trash2 className="h-3.5 w-3.5" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Delete</TooltipContent>
-					</Tooltip>
-				</div>
-			</div>
+			<ArchiveToolbar
+				selectedRows={selectedRows}
+				partStatuses={partStatuses}
+				rowData={effectiveData}
+				onExtract={() => gridApi?.exportDataAsCsv()}
+				onFilterToggle={() => setShowFilters(!showFilters)}
+				onUpdateStatus={handleUpdatePartStatus}
+				onReorder={openReorder}
+				onBooking={openBooking}
+				onDelete={openDeleteConfirm}
+				onSelectAllByVin={onSelectAllByVin}
+				isSelectAllByVinDisabled={isSelectAllByVinDisabled}
+			/>
 
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: outer wrapper captures contextmenu events; AG Grid owns all real a11y/focus management */}
 			<div
@@ -426,50 +216,20 @@ export default function ArchivePage() {
 				sourceTag="archive"
 			/>
 
-			{/* Reorder Reason Modal */}
-			<Dialog open={isReorderModalOpen} onOpenChange={setIsReorderModalOpen}>
-				<DialogContent className="bg-[#1c1c1e] border border-white/10 text-white">
-					<DialogHeader>
-						<DialogTitle className="text-orange-500">
-							Reorder - Reason Required
-						</DialogTitle>
-					</DialogHeader>
-					<div className="space-y-4">
-						<div>
-							<Label>Reason for Reorder</Label>
-							<Input
-								value={reorderReason}
-								onChange={(e) => setReorderReason(e.target.value)}
-								placeholder="e.g., Customer called back, error in archive"
-								className="bg-white/5 border-white/10 text-white"
-							/>
-						</div>
-						<p className="text-sm text-muted-foreground">
-							This will send the selected items back to the Orders view.
-						</p>
-					</div>
-					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setIsReorderModalOpen(false)}
-							className="border-white/20 text-white hover:bg-white/10"
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="renault"
-							onClick={handleConfirmReorder}
-							disabled={!reorderReason.trim()}
-						>
-							Confirm Reorder
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<ReorderReasonDialog
+				open={isReorderModalOpen}
+				onOpenChange={setReorderModalOpen}
+				reason={reorderReason}
+				onReasonChange={setReorderReason}
+				onCancel={closeReorder}
+				onConfirm={() => handleConfirmReorder(reorderReason, resetReorder)}
+				placeholder="e.g., Customer called back, error in archive"
+				helperText="This will send the selected items back to the Orders view."
+			/>
 
 			<BookingCalendarModal
 				open={isBookingModalOpen}
-				onOpenChange={setIsBookingModalOpen}
+				onOpenChange={setBookingModalOpen}
 				onConfirm={handleConfirmBooking}
 				selectedRows={selectedRows}
 			/>
@@ -477,15 +237,7 @@ export default function ArchivePage() {
 			<ConfirmDialog
 				open={showDeleteConfirm}
 				onOpenChange={setShowDeleteConfirm}
-				onConfirm={async () => {
-					applyCommand({
-						type: "deleteRows",
-						ids: getSelectedIds(selectedRows),
-					});
-					setSelectedRows([]);
-					toast.success("Archived record(s) deleted");
-					setShowDeleteConfirm(false);
-				}}
+				onConfirm={handleConfirmDelete}
 				title="Delete Archived Records"
 				description={`Are you sure you want to permanently delete ${selectedRows.length} selected record(s)?`}
 				confirmText="Permanently Delete"

--- a/src/app/(app)/archive/useArchiveModals.ts
+++ b/src/app/(app)/archive/useArchiveModals.ts
@@ -1,0 +1,34 @@
+﻿"use client";
+
+import { useState } from "react";
+
+export function useArchiveModals() {
+	const [isReorderModalOpen, setIsReorderModalOpen] = useState(false);
+	const [reorderReason, setReorderReason] = useState("");
+	const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+	return {
+		// reorder
+		isReorderModalOpen,
+		setReorderModalOpen: setIsReorderModalOpen,
+		openReorder: () => setIsReorderModalOpen(true),
+		closeReorder: () => setIsReorderModalOpen(false),
+		reorderReason,
+		setReorderReason,
+		resetReorder: () => {
+			setIsReorderModalOpen(false);
+			setReorderReason("");
+		},
+		// booking calendar modal
+		isBookingModalOpen,
+		setBookingModalOpen: setIsBookingModalOpen,
+		openBooking: () => setIsBookingModalOpen(true),
+		closeBooking: () => setIsBookingModalOpen(false),
+		// delete
+		showDeleteConfirm,
+		setShowDeleteConfirm,
+		openDeleteConfirm: () => setShowDeleteConfirm(true),
+		closeDeleteConfirm: () => setShowDeleteConfirm(false),
+	};
+}

--- a/src/app/(app)/archive/useArchivePageActions.ts
+++ b/src/app/(app)/archive/useArchivePageActions.ts
@@ -1,0 +1,111 @@
+﻿"use client";
+
+import type React from "react";
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { getSelectedIds } from "@/domain/order/orderWorkflow";
+import type { useDraftSession } from "@/hooks/useDraftSession";
+import {
+	buildBookingCommands,
+	buildReorderCommands,
+	buildSendToArchiveCommands,
+} from "@/lib/orderStageTransitions";
+import type { PendingRow } from "@/types";
+
+export function useArchivePageActions(params: {
+	applyCommand: ReturnType<typeof useDraftSession>["applyCommand"];
+	effectiveRows: PendingRow[];
+	selectedRows: PendingRow[];
+	setSelectedRows: React.Dispatch<React.SetStateAction<PendingRow[]>>;
+}) {
+	const { applyCommand, effectiveRows, selectedRows, setSelectedRows } = params;
+
+	const handleUpdateOrder = useCallback(
+		(id: string, updates: Partial<PendingRow>) => {
+			applyCommand({
+				type: "patchRow",
+				id,
+				sourceStage: "archive",
+				destinationStage: "archive",
+				updates,
+				previousValues: {},
+			});
+			return Promise.resolve();
+		},
+		[applyCommand],
+	);
+
+	const handleSendToArchive = useCallback(
+		(ids: string[], reason: string) => {
+			const rows = ids.flatMap((id) => {
+				const row = effectiveRows.find((r: PendingRow) => r.id === id);
+				return row ? [row] : [];
+			});
+			for (const cmd of buildSendToArchiveCommands(rows, reason, "archive")) {
+				applyCommand(cmd);
+			}
+		},
+		[effectiveRows, applyCommand],
+	);
+
+	const handleConfirmBooking = async (
+		date: string,
+		note: string,
+		status?: string,
+	) => {
+		for (const cmd of buildBookingCommands(
+			selectedRows,
+			"archive",
+			date,
+			note,
+			status,
+		)) {
+			applyCommand(cmd);
+		}
+		setSelectedRows([]);
+		toast.success(`${selectedRows.length} row(s) sent to Booking`);
+	};
+
+	const handleConfirmReorder = async (
+		reason: string,
+		onComplete: () => void,
+	) => {
+		if (!reason.trim()) {
+			toast.error("Please provide a reason for reorder");
+			return;
+		}
+		for (const cmd of buildReorderCommands(selectedRows, "archive", reason)) {
+			applyCommand(cmd);
+		}
+		const count = selectedRows.length;
+		setSelectedRows([]);
+		onComplete();
+		toast.success(`${count} row(s) sent back to Orders (Reorder)`);
+	};
+
+	const handleUpdatePartStatus = (status: string) => {
+		if (selectedRows.length === 0) return;
+		selectedRows.forEach((row) => {
+			handleUpdateOrder(row.id, { status });
+		});
+		toast.success(`Updated ${selectedRows.length} item(s) to ${status}`);
+	};
+
+	const handleConfirmDelete = async () => {
+		applyCommand({
+			type: "deleteRows",
+			ids: getSelectedIds(selectedRows),
+		});
+		setSelectedRows([]);
+		toast.success("Archived record(s) deleted");
+	};
+
+	return {
+		handleUpdateOrder,
+		handleSendToArchive,
+		handleConfirmBooking,
+		handleConfirmReorder,
+		handleUpdatePartStatus,
+		handleConfirmDelete,
+	};
+}

--- a/src/components/archive/ArchiveToolbar.tsx
+++ b/src/components/archive/ArchiveToolbar.tsx
@@ -1,0 +1,200 @@
+﻿"use client";
+
+import {
+	Calendar,
+	CheckCircle,
+	Download,
+	Filter,
+	RotateCcw,
+	Trash2,
+} from "lucide-react";
+import { LayoutSaveButton } from "@/components/shared/LayoutSaveButton";
+import { SelectAllByVinButton } from "@/components/shared/SelectAllByVinButton";
+import { VINLineCounter } from "@/components/shared/VINLineCounter";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useColumnLayoutTracker } from "@/hooks/useColumnLayoutTracker";
+import { cn } from "@/lib/utils";
+import type { PartStatusDef, PendingRow } from "@/types";
+
+export interface ArchiveToolbarProps {
+	selectedRows: PendingRow[];
+	partStatuses?: PartStatusDef[];
+	rowData?: PendingRow[];
+	onExtract: () => void;
+	onFilterToggle: () => void;
+	onUpdateStatus: (statusLabel: string) => void;
+	onReorder: () => void;
+	onBooking: () => void;
+	onDelete: () => void;
+	onSelectAllByVin: () => void;
+	isSelectAllByVinDisabled: boolean;
+}
+
+export function ArchiveToolbar({
+	selectedRows = [],
+	partStatuses = [],
+	rowData = [],
+	onExtract,
+	onFilterToggle,
+	onUpdateStatus,
+	onReorder,
+	onBooking,
+	onDelete,
+	onSelectAllByVin,
+	isSelectAllByVinDisabled,
+}: ArchiveToolbarProps) {
+	const { isDirty, isPositionDirty, saveLayout, saveAsDefault, resetLayout } =
+		useColumnLayoutTracker("archive");
+
+	return (
+		<div className="flex items-center justify-between bg-[#141416] p-1.5 rounded-lg border border-white/5">
+			<div className="flex items-center gap-1.5">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							className="bg-[#1c1c1e] hover:bg-[#2c2c2e] text-gray-300 border-none rounded-md h-8 w-8"
+							onClick={onExtract}
+						>
+							<Download className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Extract</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-gray-400 hover:text-white h-8 w-8"
+							onClick={onFilterToggle}
+						>
+							<Filter className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Filter</TooltipContent>
+				</Tooltip>
+
+				<LayoutSaveButton
+					isDirty={isDirty}
+					isPositionDirty={isPositionDirty}
+					onSave={saveLayout}
+					onSaveAsDefault={saveAsDefault}
+					onReset={resetLayout}
+				/>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="text-gray-400 hover:text-white h-8 w-8"
+									disabled={selectedRows.length === 0}
+								>
+									<CheckCircle className="h-4 w-4" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								align="end"
+								className="bg-[#1c1c1e] border-white/10 text-white min-w-[160px]"
+							>
+								{partStatuses?.map((status) => {
+									const isHex =
+										status.color?.startsWith("#") ||
+										status.color?.startsWith("rgb");
+									const dotStyle = isHex
+										? { backgroundColor: status.color }
+										: undefined;
+									const colorClass = isHex ? "" : status.color;
+
+									return (
+										<DropdownMenuItem
+											key={status.id}
+											onClick={() => onUpdateStatus(status.label)}
+											className="flex items-center gap-2 focus:bg-white/5 cursor-pointer"
+										>
+											<div
+												className={cn("w-2 h-2 rounded-full", colorClass)}
+												style={dotStyle}
+											/>
+											<span className="text-xs">{status.label}</span>
+										</DropdownMenuItem>
+									);
+								})}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</TooltipTrigger>
+					<TooltipContent>Update Status</TooltipContent>
+				</Tooltip>
+
+				<div className="w-px h-5 bg-white/10 mx-1" />
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-orange-500/80 hover:text-orange-500 h-8 w-8"
+							onClick={onReorder}
+							disabled={selectedRows.length === 0}
+						>
+							<RotateCcw className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Reorder</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-green-500/80 hover:text-green-500 h-8 w-8"
+							onClick={onBooking}
+							disabled={selectedRows.length === 0}
+						>
+							<Calendar className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Reschedule Booking</TooltipContent>
+				</Tooltip>
+			</div>
+
+			<div className="flex items-center gap-1.5">
+				<SelectAllByVinButton
+					onSelectAllByVin={onSelectAllByVin}
+					isDisabled={isSelectAllByVinDisabled}
+				/>
+				<VINLineCounter rows={rowData} />
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							size="icon"
+							variant="ghost"
+							className="text-red-500 hover:text-red-400 hover:bg-red-500/10 h-8 w-8"
+							onClick={onDelete}
+							disabled={selectedRows.length === 0}
+						>
+							<Trash2 className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Delete</TooltipContent>
+				</Tooltip>
+			</div>
+		</div>
+	);
+}

--- a/src/test/ArchiveToolbar.test.tsx
+++ b/src/test/ArchiveToolbar.test.tsx
@@ -1,0 +1,149 @@
+﻿import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+	ArchiveToolbar,
+	type ArchiveToolbarProps,
+} from "@/components/archive/ArchiveToolbar";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { PartStatusDef, PendingRow } from "@/types";
+
+const renderWithProvider = (ui: React.ReactElement) => {
+	return render(<TooltipProvider>{ui}</TooltipProvider>);
+};
+
+const getButtonByIcon = (container: HTMLElement, iconClass: string) => {
+	const btn = container.querySelector(`.${iconClass}`)?.closest("button");
+	if (!btn) {
+		throw new Error(`Button with icon .${iconClass} not found`);
+	}
+	return btn;
+};
+
+const mockSelectedRows: PendingRow[] = [
+	{
+		id: "1",
+		vin: "VF1BB0A0F12345678",
+		customerName: "Test Customer",
+		stage: "archive",
+	} as PendingRow,
+];
+
+const mockPartStatuses: PartStatusDef[] = [
+	{ id: "1", label: "Reserve", color: "#ff0000" },
+	{ id: "2", label: "Under Inspection", color: "text-blue-500" },
+];
+
+const defaultProps: ArchiveToolbarProps = {
+	selectedRows: mockSelectedRows,
+	partStatuses: mockPartStatuses,
+	rowData: mockSelectedRows,
+	onExtract: vi.fn(),
+	onFilterToggle: vi.fn(),
+	onUpdateStatus: vi.fn(),
+	onReorder: vi.fn(),
+	onBooking: vi.fn(),
+	onDelete: vi.fn(),
+	onSelectAllByVin: vi.fn(),
+	isSelectAllByVinDisabled: false,
+};
+
+describe("ArchiveToolbar", () => {
+	it("disables Update Status, Reorder, Reschedule Booking, and Delete when selectedRows is empty", () => {
+		const { container } = renderWithProvider(
+			<ArchiveToolbar {...defaultProps} selectedRows={[]} />,
+		);
+
+		expect(
+			getButtonByIcon(container, "lucide-circle-check-big"),
+		).toBeDisabled();
+		expect(getButtonByIcon(container, "lucide-rotate-ccw")).toBeDisabled();
+		expect(getButtonByIcon(container, "lucide-calendar")).toBeDisabled();
+		expect(getButtonByIcon(container, "lucide-trash2")).toBeDisabled();
+	});
+
+	it("enables action buttons when rows are selected", () => {
+		const { container } = renderWithProvider(
+			<ArchiveToolbar {...defaultProps} selectedRows={mockSelectedRows} />,
+		);
+
+		expect(getButtonByIcon(container, "lucide-circle-check-big")).toBeEnabled();
+		expect(getButtonByIcon(container, "lucide-rotate-ccw")).toBeEnabled();
+		expect(getButtonByIcon(container, "lucide-calendar")).toBeEnabled();
+		expect(getButtonByIcon(container, "lucide-trash2")).toBeEnabled();
+	});
+
+	it("calls onExtract when Extract is clicked", () => {
+		const onExtract = vi.fn();
+		const { container } = renderWithProvider(
+			<ArchiveToolbar {...defaultProps} onExtract={onExtract} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-download");
+		fireEvent.click(btn);
+		expect(onExtract).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onFilterToggle when Filter is clicked", () => {
+		const onFilterToggle = vi.fn();
+		const { container } = renderWithProvider(
+			<ArchiveToolbar {...defaultProps} onFilterToggle={onFilterToggle} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-filter");
+		fireEvent.click(btn);
+		expect(onFilterToggle).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onReorder when Reorder button is clicked", () => {
+		const onReorder = vi.fn();
+		const { container } = renderWithProvider(
+			<ArchiveToolbar {...defaultProps} onReorder={onReorder} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-rotate-ccw");
+		fireEvent.click(btn);
+		expect(onReorder).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onBooking when Reschedule Booking button is clicked", () => {
+		const onBooking = vi.fn();
+		const { container } = renderWithProvider(
+			<ArchiveToolbar {...defaultProps} onBooking={onBooking} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-calendar");
+		fireEvent.click(btn);
+		expect(onBooking).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onDelete when Delete button is clicked", () => {
+		const onDelete = vi.fn();
+		const { container } = renderWithProvider(
+			<ArchiveToolbar {...defaultProps} onDelete={onDelete} />,
+		);
+		const btn = getButtonByIcon(container, "lucide-trash2");
+		fireEvent.click(btn);
+		expect(onDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders items for each partStatus and calls onUpdateStatus when clicked", async () => {
+		const user = userEvent.setup();
+		const onUpdateStatus = vi.fn();
+		const { container } = renderWithProvider(
+			<ArchiveToolbar
+				{...defaultProps}
+				partStatuses={mockPartStatuses}
+				onUpdateStatus={onUpdateStatus}
+			/>,
+		);
+		const trigger = getButtonByIcon(container, "lucide-circle-check-big");
+		await user.click(trigger);
+
+		const reserveItem = await screen.findByText("Reserve");
+		const inspectionItem = await screen.findByText("Under Inspection");
+		expect(reserveItem).toBeInTheDocument();
+		expect(inspectionItem).toBeInTheDocument();
+
+		await user.click(reserveItem);
+		expect(onUpdateStatus).toHaveBeenCalledWith("Reserve");
+	});
+});

--- a/src/test/ReorderReasonDialogArchive.test.tsx
+++ b/src/test/ReorderReasonDialogArchive.test.tsx
@@ -1,0 +1,117 @@
+﻿import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ReorderReasonDialog } from "@/components/shared/ReorderReasonDialog";
+
+vi.mock("@/components/ui/dialog", () => ({
+	Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+		open ? <div data-testid="reorder-dialog">{children}</div> : null,
+	DialogContent: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogHeader: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DialogTitle: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogDescription: ({
+		children,
+		className,
+	}: {
+		children: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+	DialogFooter: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+describe("ReorderReasonDialog - Archive adoption", () => {
+	const archiveProps = {
+		open: true,
+		onOpenChange: vi.fn(),
+		reason: "",
+		onReasonChange: vi.fn(),
+		onCancel: vi.fn(),
+		onConfirm: vi.fn(),
+		placeholder: "e.g., Customer called back, error in archive",
+		helperText: "This will send the selected items back to the Orders view.",
+	};
+
+	it("renders Archive placeholder, renders helperText, and does NOT render srDescription", () => {
+		const { container } = render(<ReorderReasonDialog {...archiveProps} />);
+
+		expect(
+			screen.getByPlaceholderText(
+				"e.g., Customer called back, error in archive",
+			),
+		).toBeInTheDocument();
+
+		// Helper text element IS rendered
+		const helperP = container.querySelector(".text-muted-foreground");
+		expect(helperP).not.toBeNull();
+		expect(
+			screen.getByText(
+				"This will send the selected items back to the Orders view.",
+			),
+		).toBeInTheDocument();
+
+		// No sr-only description element rendered
+		const srOnlyEl = container.querySelector(".sr-only");
+		expect(srOnlyEl).toBeNull();
+	});
+
+	it("keeps Confirm Reorder disabled when reason is blank, and enables it when filled", () => {
+		const { rerender } = render(
+			<ReorderReasonDialog {...archiveProps} reason="" />,
+		);
+
+		const confirmBtn = screen.getByRole("button", {
+			name: /confirm reorder/i,
+		});
+		expect(confirmBtn).toBeDisabled();
+
+		rerender(<ReorderReasonDialog {...archiveProps} reason="   " />);
+		expect(confirmBtn).toBeDisabled();
+
+		rerender(
+			<ReorderReasonDialog
+				{...archiveProps}
+				reason="Customer called back, error in archive"
+			/>,
+		);
+		expect(confirmBtn).toBeEnabled();
+	});
+
+	it("calls onConfirm when Confirm Reorder is clicked with non-empty reason", () => {
+		const onConfirm = vi.fn();
+		render(
+			<ReorderReasonDialog
+				{...archiveProps}
+				reason="Valid reason"
+				onConfirm={onConfirm}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /confirm reorder/i }));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		const onCancel = vi.fn();
+		render(<ReorderReasonDialog {...archiveProps} onCancel={onCancel} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/test/useArchiveModals.test.ts
+++ b/src/test/useArchiveModals.test.ts
@@ -1,0 +1,190 @@
+﻿import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useArchiveModals } from "@/app/(app)/archive/useArchiveModals";
+
+describe("useArchiveModals", () => {
+	it("initializes with all modals closed and an empty reorderReason", () => {
+		const { result } = renderHook(() => useArchiveModals());
+
+		expect(result.current.isReorderModalOpen).toBe(false);
+		expect(result.current.reorderReason).toBe("");
+		expect(result.current.isBookingModalOpen).toBe(false);
+		expect(result.current.showDeleteConfirm).toBe(false);
+	});
+
+	describe("reorder modal", () => {
+		it("openReorder() opens modal; closeReorder() closes it and leaves reorderReason unchanged", () => {
+			const { result } = renderHook(() => useArchiveModals());
+
+			act(() => {
+				result.current.setReorderReason("Wrong part supplied");
+			});
+			expect(result.current.reorderReason).toBe("Wrong part supplied");
+
+			act(() => {
+				result.current.openReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+
+			act(() => {
+				result.current.closeReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("Wrong part supplied");
+		});
+
+		it("resetReorder() closes modal and clears reorderReason to empty string", () => {
+			const { result } = renderHook(() => useArchiveModals());
+
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Customer cancelled");
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.reorderReason).toBe("Customer cancelled");
+
+			act(() => {
+				result.current.resetReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("");
+		});
+
+		it("setReorderModalOpen(false) (the onOpenChange path) closes without clearing a set reason", () => {
+			const { result } = renderHook(() => useArchiveModals());
+
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Part defective");
+			});
+
+			act(() => {
+				result.current.setReorderModalOpen(false);
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.reorderReason).toBe("Part defective");
+
+			act(() => {
+				result.current.setReorderModalOpen(true);
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.reorderReason).toBe("Part defective");
+		});
+	});
+
+	describe("booking calendar modal", () => {
+		it("openBooking() and closeBooking() toggle isBookingModalOpen only", () => {
+			const { result } = renderHook(() => useArchiveModals());
+
+			act(() => {
+				result.current.openBooking();
+			});
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+
+			act(() => {
+				result.current.closeBooking();
+			});
+			expect(result.current.isBookingModalOpen).toBe(false);
+		});
+
+		it("setBookingModalOpen() directly controls isBookingModalOpen for onOpenChange", () => {
+			const { result } = renderHook(() => useArchiveModals());
+
+			act(() => {
+				result.current.setBookingModalOpen(true);
+			});
+			expect(result.current.isBookingModalOpen).toBe(true);
+
+			act(() => {
+				result.current.setBookingModalOpen(false);
+			});
+			expect(result.current.isBookingModalOpen).toBe(false);
+		});
+	});
+
+	describe("delete confirm modal", () => {
+		it("openDeleteConfirm() and closeDeleteConfirm() toggle showDeleteConfirm only", () => {
+			const { result } = renderHook(() => useArchiveModals());
+
+			act(() => {
+				result.current.openDeleteConfirm();
+			});
+			expect(result.current.showDeleteConfirm).toBe(true);
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.isBookingModalOpen).toBe(false);
+
+			act(() => {
+				result.current.closeDeleteConfirm();
+			});
+			expect(result.current.showDeleteConfirm).toBe(false);
+		});
+
+		it("setShowDeleteConfirm() directly controls showDeleteConfirm for onOpenChange", () => {
+			const { result } = renderHook(() => useArchiveModals());
+
+			act(() => {
+				result.current.setShowDeleteConfirm(true);
+			});
+			expect(result.current.showDeleteConfirm).toBe(true);
+
+			act(() => {
+				result.current.setShowDeleteConfirm(false);
+			});
+			expect(result.current.showDeleteConfirm).toBe(false);
+		});
+	});
+
+	describe("cross-independence", () => {
+		it("opening one modal does not change the other modals or mutate state unexpectedly", () => {
+			const { result } = renderHook(() => useArchiveModals());
+
+			// Open reorder
+			act(() => {
+				result.current.openReorder();
+				result.current.setReorderReason("Test reason");
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+
+			// Open booking
+			act(() => {
+				result.current.openBooking();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Open delete confirm
+			act(() => {
+				result.current.openDeleteConfirm();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(true);
+			expect(result.current.showDeleteConfirm).toBe(true);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Close booking & delete confirm - reorder remains open with reason intact
+			act(() => {
+				result.current.closeBooking();
+				result.current.closeDeleteConfirm();
+			});
+			expect(result.current.isReorderModalOpen).toBe(true);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("Test reason");
+
+			// Reset reorder clears reason and closes reorder modal
+			act(() => {
+				result.current.resetReorder();
+			});
+			expect(result.current.isReorderModalOpen).toBe(false);
+			expect(result.current.isBookingModalOpen).toBe(false);
+			expect(result.current.showDeleteConfirm).toBe(false);
+			expect(result.current.reorderReason).toBe("");
+		});
+	});
+});

--- a/src/test/useArchivePageActions.test.ts
+++ b/src/test/useArchivePageActions.test.ts
@@ -1,0 +1,493 @@
+﻿import { act, renderHook } from "@testing-library/react";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useArchivePageActions } from "@/app/(app)/archive/useArchivePageActions";
+import {
+	buildBookingCommands,
+	buildReorderCommands,
+	buildSendToArchiveCommands,
+} from "@/lib/orderStageTransitions";
+import type { PendingRow } from "@/types";
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock("@/lib/orderStageTransitions", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/orderStageTransitions")>();
+	return {
+		...actual,
+		buildReorderCommands: vi.fn(actual.buildReorderCommands),
+		buildBookingCommands: vi.fn(actual.buildBookingCommands),
+		buildSendToArchiveCommands: vi.fn(actual.buildSendToArchiveCommands),
+	};
+});
+
+const createRow = (overrides: Partial<PendingRow> = {}): PendingRow => ({
+	id: crypto.randomUUID(),
+	baseId: "B1",
+	trackingId: "T1",
+	customerName: "Test Customer",
+	mobile: "123456789",
+	parts: [],
+	status: "Pending",
+	rDate: "2024-01-01",
+	requester: "Admin",
+	acceptedBy: "Admin",
+	sabNumber: "S1",
+	model: "Clio",
+	cntrRdg: 1000,
+	repairSystem: "None",
+	startWarranty: "",
+	endWarranty: "",
+	remainTime: "",
+	partNumber: "P1",
+	description: "Test Part",
+	quantity: 1,
+	vin: "VF1BB0A0F12345678",
+	stage: "archive",
+	...overrides,
+});
+
+describe("useArchivePageActions", () => {
+	const applyCommand = vi.fn();
+	const setSelectedRows = vi.fn();
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+		vi.clearAllMocks();
+		applyCommand.mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("handleConfirmReorder", () => {
+		it("rejects reorder when reason is empty or whitespace-only without calling applyCommand, setSelectedRows, or onComplete", async () => {
+			const row = createRow();
+			const onComplete = vi.fn();
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("", onComplete);
+			});
+
+			expect(toast.error).toHaveBeenCalledWith(
+				"Please provide a reason for reorder",
+			);
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(setSelectedRows).not.toHaveBeenCalled();
+			expect(onComplete).not.toHaveBeenCalled();
+
+			vi.clearAllMocks();
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("   ", onComplete);
+			});
+
+			expect(toast.error).toHaveBeenCalledWith(
+				"Please provide a reason for reorder",
+			);
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(setSelectedRows).not.toHaveBeenCalled();
+			expect(onComplete).not.toHaveBeenCalled();
+		});
+
+		it("reorders rows individually, clears selection, calls onComplete, and toasts with correct order", async () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const selected = [row1, row2];
+			const onComplete = vi.fn();
+
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmReorder("Damaged item", onComplete);
+			});
+
+			expect(buildReorderCommands).toHaveBeenCalledTimes(1);
+			expect(buildReorderCommands).toHaveBeenCalledWith(
+				selected,
+				"archive",
+				"Damaged item",
+			);
+
+			expect(applyCommand).toHaveBeenCalledTimes(selected.length);
+			for (const call of applyCommand.mock.calls) {
+				expect(call[0]).toMatchObject({
+					type: "patchRow",
+					sourceStage: "archive",
+					destinationStage: "orders",
+				});
+			}
+
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(onComplete).toHaveBeenCalledTimes(1);
+			expect(toast.success).toHaveBeenCalledWith(
+				"2 row(s) sent back to Orders (Reorder)",
+			);
+
+			// Preserved order: applyCommand -> setSelectedRows -> onComplete -> toast.success
+			const lastApply = Math.max(...applyCommand.mock.invocationCallOrder);
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const complete = onComplete.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(lastApply).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(complete);
+			expect(complete).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleConfirmBooking", () => {
+		it("replays buildBookingCommands output, clears selection, and toasts success", async () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmBooking(
+					"2026-02-15",
+					"Customer requested booking",
+					"Confirmed",
+				);
+			});
+
+			expect(buildBookingCommands).toHaveBeenCalledTimes(1);
+			expect(buildBookingCommands).toHaveBeenCalledWith(
+				selected,
+				"archive",
+				"2026-02-15",
+				"Customer requested booking",
+				"Confirmed",
+			);
+
+			expect(applyCommand).toHaveBeenCalledTimes(selected.length);
+			for (const call of applyCommand.mock.calls) {
+				expect(call[0]).toMatchObject({
+					type: "patchRow",
+					sourceStage: "archive",
+					destinationStage: "booking",
+				});
+			}
+
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(toast.success).toHaveBeenCalledWith("2 row(s) sent to Booking");
+
+			const lastApply = Math.max(...applyCommand.mock.invocationCallOrder);
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(lastApply).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleUpdatePartStatus", () => {
+		it("updates part status for all selected rows with individual patchRow commands", () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleUpdatePartStatus("Reserve");
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(2);
+			expect(applyCommand).toHaveBeenNthCalledWith(1, {
+				type: "patchRow",
+				id: row1.id,
+				sourceStage: "archive",
+				destinationStage: "archive",
+				updates: { status: "Reserve" },
+				previousValues: {},
+			});
+			expect(applyCommand).toHaveBeenNthCalledWith(2, {
+				type: "patchRow",
+				id: row2.id,
+				sourceStage: "archive",
+				destinationStage: "archive",
+				updates: { status: "Reserve" },
+				previousValues: {},
+			});
+			expect(toast.success).toHaveBeenCalledWith(
+				"Updated 2 item(s) to Reserve",
+			);
+		});
+
+		it("no-ops for handleUpdatePartStatus when selectedRows is empty", () => {
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: [],
+					selectedRows: [],
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleUpdatePartStatus("Reserve");
+			});
+
+			expect(applyCommand).not.toHaveBeenCalled();
+			expect(toast.success).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("handleConfirmDelete", () => {
+		it("deletes selected rows in a single batch, clears selection, and toasts", async () => {
+			const uuid1 = crypto.randomUUID();
+			const uuid2 = crypto.randomUUID();
+			const row1 = createRow({ id: uuid1 });
+			const row2 = createRow({ id: uuid2 });
+			const selected = [row1, row2];
+
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: selected,
+					selectedRows: selected,
+					setSelectedRows,
+				}),
+			);
+
+			await act(async () => {
+				await result.current.handleConfirmDelete();
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith({
+				type: "deleteRows",
+				ids: [uuid1, uuid2],
+			});
+			expect(setSelectedRows).toHaveBeenCalledWith([]);
+			expect(toast.success).toHaveBeenCalledWith("Archived record(s) deleted");
+
+			// Preserved order: applyCommand -> setSelectedRows -> toast.success
+			const applyOrder = applyCommand.mock.invocationCallOrder[0];
+			const setSel = setSelectedRows.mock.invocationCallOrder[0];
+			const toastSuccess = vi.mocked(toast.success).mock.invocationCallOrder[0];
+
+			expect(applyOrder).toBeLessThan(setSel);
+			expect(setSel).toBeLessThan(toastSuccess);
+		});
+	});
+
+	describe("handleUpdateOrder", () => {
+		it("dispatches patchRow command targeting archive stage and resolves", async () => {
+			const row = createRow();
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			let resolvedValue: unknown;
+			await act(async () => {
+				resolvedValue = await result.current.handleUpdateOrder(row.id, {
+					customerName: "New Name",
+				});
+			});
+
+			expect(resolvedValue).toBeUndefined();
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith({
+				type: "patchRow",
+				id: row.id,
+				sourceStage: "archive",
+				destinationStage: "archive",
+				updates: { customerName: "New Name" },
+				previousValues: {},
+			});
+		});
+	});
+
+	describe("handleSendToArchive", () => {
+		it("preserves ID ordering and silently drops unknown IDs when archiving", () => {
+			const row1 = createRow({ id: crypto.randomUUID() });
+			const row2 = createRow({ id: crypto.randomUUID() });
+			const row3 = createRow({ id: crypto.randomUUID() });
+			const unknownId = crypto.randomUUID();
+
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: [row1, row2, row3],
+					selectedRows: [],
+					setSelectedRows,
+				}),
+			);
+
+			act(() => {
+				result.current.handleSendToArchive(
+					[row3.id, unknownId, row1.id],
+					"Scrapped",
+				);
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(2);
+			expect(applyCommand).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining({
+					id: row3.id,
+					sourceStage: "archive",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						status: "Archived",
+						archiveReason: "Scrapped",
+						archivedAt: "2026-01-01T00:00:00.000Z",
+					}),
+				}),
+			);
+			expect(applyCommand).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					id: row1.id,
+					sourceStage: "archive",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						status: "Archived",
+						archiveReason: "Scrapped",
+						archivedAt: "2026-01-01T00:00:00.000Z",
+					}),
+				}),
+			);
+		});
+
+		it("resolves rows from refreshed effectiveRows after rerender", () => {
+			const rowA = createRow({ id: crypto.randomUUID() });
+			const rowB = createRow({ id: crypto.randomUUID() });
+
+			const { result, rerender } = renderHook(
+				({ rows }) =>
+					useArchivePageActions({
+						applyCommand,
+						effectiveRows: rows,
+						selectedRows: [],
+						setSelectedRows,
+					}),
+				{ initialProps: { rows: [rowA] } },
+			);
+
+			// rowB is not in initial rows, so it should be dropped
+			act(() => {
+				result.current.handleSendToArchive([rowB.id], "Initial attempt");
+			});
+			expect(applyCommand).not.toHaveBeenCalled();
+
+			// Rerender with refreshed rows containing rowB
+			rerender({ rows: [rowA, rowB] });
+
+			act(() => {
+				result.current.handleSendToArchive([rowB.id], "After rerender");
+			});
+
+			expect(applyCommand).toHaveBeenCalledTimes(1);
+			expect(applyCommand).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: rowB.id,
+					sourceStage: "archive",
+					destinationStage: "archive",
+					updates: expect.objectContaining({
+						archiveReason: "After rerender",
+					}),
+				}),
+			);
+		});
+	});
+
+	describe("builder delegation", () => {
+		it("explicitly delegates to real builder functions (buildReorderCommands, buildBookingCommands, buildSendToArchiveCommands) with expected arguments", async () => {
+			const row = createRow({
+				id: crypto.randomUUID(),
+			});
+			const onComplete = vi.fn();
+
+			const { result } = renderHook(() =>
+				useArchivePageActions({
+					applyCommand,
+					effectiveRows: [row],
+					selectedRows: [row],
+					setSelectedRows,
+				}),
+			);
+
+			// 1. buildReorderCommands delegation
+			await act(async () => {
+				await result.current.handleConfirmReorder("Defective part", onComplete);
+			});
+			expect(vi.mocked(buildReorderCommands)).toHaveBeenCalledWith(
+				[row],
+				"archive",
+				"Defective part",
+			);
+
+			// 2. buildBookingCommands delegation
+			await act(async () => {
+				await result.current.handleConfirmBooking(
+					"2026-02-10",
+					"Customer confirmed",
+					"Confirmed",
+				);
+			});
+			expect(vi.mocked(buildBookingCommands)).toHaveBeenCalledWith(
+				[row],
+				"archive",
+				"2026-02-10",
+				"Customer confirmed",
+				"Confirmed",
+			);
+
+			// 3. buildSendToArchiveCommands delegation
+			act(() => {
+				result.current.handleSendToArchive([row.id], "Customer cancelled");
+			});
+			expect(vi.mocked(buildSendToArchiveCommands)).toHaveBeenCalledWith(
+				[row],
+				"Customer cancelled",
+				"archive",
+			);
+		});
+	});
+});


### PR DESCRIPTION
Closes #182.

Applies the four-part stage extraction shape (Booking #175–#178, Call List #180, Main Sheet #181) to the **Archive** page, the fourth and final adopter. Every Archive-specific behavior and copy string is preserved verbatim — no normalization toward the other stages.

## Changes

| File | |
|---|---|
| `src/app/(app)/archive/useArchivePageActions.ts` | **new** — action-handler hook; `handleConfirmReorder(reason, onComplete)`; simple per-row `handleUpdatePartStatus` (like Call List); `handleConfirmDelete` keeps toast `"Archived record(s) deleted"` and drops the redundant `setShowDeleteConfirm(false)`; no `handleDelete` gate |
| `src/app/(app)/archive/useArchiveModals.ts` | **new** — modal-state hook, verbatim copy of `useMainSheetModals` |
| `src/components/archive/ArchiveToolbar.tsx` | **new** — presentational toolbar, JSX/classes/tooltips byte-for-byte; owns `useColumnLayoutTracker("archive")` |
| `src/app/(app)/archive/page.tsx` | rewritten to wire the three artifacts + adopt shared `ReorderReasonDialog`; drops unused `useCallback`; 495 → 248 LOC |
| `src/test/*` (4 files) | **new** — 31 tests mirroring the ticket-01 approach |
| `FINDING_STAGE_EXTRACTION_REUSE.md` | n=4 resolution note — stay stage-specific permanently |

## Gates

- `tsc --noEmit` — clean
- `biome check` on changed files — clean
- `vitest run` — **835 passed** (31 new)

## Review

Ran `/debate-review` (main `codex/gpt-5.6-sol` high, debate `claude/fable`): **0 blocking**, 3 × P2 non-blocking.
- F1 (contested) — removed explicit delete-dialog close: deliberate, mirrors `call-list`/`main-sheet`; `ConfirmDialog` self-closes synchronously.
- F2 (contested) — hooks co-located under `app/`: the established convention across all prior stages; not changing Archive alone.
- F3 (agreed) — **fixed**: decision-record note now says "fourth adopter".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWw5moCdMwQ4BRZbcWpKq6